### PR TITLE
Rename customersMain to customers

### DIFF
--- a/backend/core-api/src/modules/contacts/graphql/resolvers/queries/customer.ts
+++ b/backend/core-api/src/modules/contacts/graphql/resolvers/queries/customer.ts
@@ -23,19 +23,6 @@ export const customerQueries = {
    * Customers list
    */
   async customers(
-    _parent: undefined,
-    params: ICustomerQueryFilterParams,
-    { models }: IContext,
-  ) {
-    const filter = generateFilter(params);
-
-    return await paginate(models.Customers.find(filter), params);
-  },
-
-  /**
-   * Customers for only main list
-   */
-  async customersMain(
     _root,
     params: ICustomerQueryFilterParams,
     { models }: IContext,

--- a/backend/core-api/src/modules/contacts/graphql/schemas/customer.ts
+++ b/backend/core-api/src/modules/contacts/graphql/schemas/customer.ts
@@ -49,6 +49,7 @@ export const types = `
     score: Float
     links: JSON
     companies: [Company]
+    getTags: [Tag]
   }
 
   type CustomersListResponse {
@@ -95,8 +96,7 @@ const queryParams = `
 `;
 
 export const queries = `
-  customers(${queryParams}): [Customer]
-  customersMain(${queryParams}): CustomersListResponse
+  customers(${queryParams}): CustomersListResponse
   customerDetail(_id: String!): Customer
 `;
 

--- a/frontend/core-ui/src/modules/contacts/graphql/queries/getCustomers.ts
+++ b/frontend/core-ui/src/modules/contacts/graphql/queries/getCustomers.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const GET_CUSTOMERS = gql`
-  query customersMain(
+  query customers(
     $page: Int
     $perPage: Int
     $segment: String
@@ -29,7 +29,7 @@ export const GET_CUSTOMERS = gql`
     $isRelated: Boolean
     $isSaved: Boolean
   ) {
-    customersMain(
+    customers(
       page: $page
       perPage: $perPage
       segment: $segment

--- a/frontend/core-ui/src/modules/contacts/hooks/useAddCustomer.tsx
+++ b/frontend/core-ui/src/modules/contacts/hooks/useAddCustomer.tsx
@@ -4,7 +4,7 @@ import { GET_CUSTOMERS } from '@/contacts/graphql/queries/getCustomers';
 import { ICustomer } from '@/contacts/types/customerType';
 
 interface CustomerData {
-  customersMain: {
+  customers: {
     list: ICustomer[];
     totalCount: number;
   };
@@ -28,21 +28,17 @@ export function useAddCustomer(
             query: GET_CUSTOMERS,
             variables: queryVariables,
           });
-          if (
-            !existingData ||
-            !existingData.customersMain ||
-            !data?.customersAdd
-          )
+          if (!existingData || !existingData.customers || !data?.customersAdd)
             return;
 
           cache.writeQuery<CustomerData>({
             query: GET_CUSTOMERS,
             variables: queryVariables,
             data: {
-              customersMain: {
-                ...existingData.customersMain,
-                list: [data.customersAdd, ...existingData.customersMain.list],
-                totalCount: existingData.customersMain.totalCount + 1,
+              customers: {
+                ...existingData.customers,
+                list: [data.customersAdd, ...existingData.customers.list],
+                totalCount: existingData.customers.totalCount + 1,
               },
             },
           });

--- a/frontend/core-ui/src/modules/contacts/hooks/useCustomers.tsx
+++ b/frontend/core-ui/src/modules/contacts/hooks/useCustomers.tsx
@@ -3,7 +3,7 @@ import { QueryHookOptions, useQuery } from '@apollo/client';
 import { useContactFilterValues } from '@/contacts/contacts-filter/hooks/useContactFilterValues';
 import { GET_CUSTOMERS } from '@/contacts/graphql/queries/getCustomers';
 
-export const   CUSTOMERS_PER_PAGE = 30;
+export const CUSTOMERS_PER_PAGE = 30;
 
 export const useCustomers = (options?: QueryHookOptions) => {
   const { variables } = useContactFilterValues();
@@ -14,9 +14,8 @@ export const useCustomers = (options?: QueryHookOptions) => {
       ...variables,
     },
   });
-  
 
-  const { list: customers, totalCount } = data?.customersMain || {};
+  const { list: customers, totalCount } = data?.customers || {};
 
   const handleFetchMore = () =>
     totalCount > customers?.length &&
@@ -28,11 +27,11 @@ export const useCustomers = (options?: QueryHookOptions) => {
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) return prev;
         return Object.assign({}, prev, {
-          customersMain: {
-            ...prev.customersMain,
+          customers: {
+            ...prev.customers,
             list: [
-              ...(prev.customersMain?.list || []),
-              ...(fetchMoreResult.customersMain?.list || []),
+              ...(prev.customers?.list || []),
+              ...(fetchMoreResult.customers?.list || []),
             ],
           },
         });

--- a/frontend/core-ui/src/providers/apollo-provider/apolloClient.ts
+++ b/frontend/core-ui/src/providers/apollo-provider/apolloClient.ts
@@ -70,7 +70,7 @@ const link = split(
 );
 
 const typePolicies = {
-  customersMain: {
+  customers: {
     keyFields: ['_id'],
   },
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `customersMain` to `customers` across backend and frontend components for consistency.
> 
>   - **GraphQL Resolvers and Schemas**:
>     - Rename `customersMain` to `customers` in `customer.ts` and `customer.ts` schema.
>     - Update return type of `customers` query to `CustomersListResponse`.
>   - **Frontend Queries and Hooks**:
>     - Rename `customersMain` to `customers` in `getCustomers.ts`.
>     - Update `useAddCustomer.tsx` and `useCustomers.tsx` to use `customers` instead of `customersMain`.
>   - **Apollo Client**:
>     - Update `typePolicies` in `apolloClient.ts` to use `customers` key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for bac00b5778d481ec67a833bf70f06a4c5760a91c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled retrieval of customer tags.
	- Updated customer responses to include a total count.

- **Refactor**
	- Consolidated customer query functionalities for a streamlined experience.
	- Standardized naming conventions across queries, hooks, and cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->