### PR TITLE
fix: update query logic for Department and Structures in structuresQueries

### DIFF
--- a/backend/core-api/src/apollo/schema/schema.ts
+++ b/backend/core-api/src/apollo/schema/schema.ts
@@ -32,6 +32,7 @@ import {
 } from '@/organization/structure/graphql/schemas/position';
 import {
   mutations as structuresMutations,
+  queries as structuresQueries,
   StructureTypes,
 } from '@/organization/structure/graphql/schemas/structure';
 import {
@@ -118,6 +119,7 @@ export const queries = `
     ${branchsQueries}
     ${departmentsQueries}
     ${positionsQueries}
+    ${structuresQueries}
     ${unitsQueries}
     ${AppQueries}
     ${RelationQueries}

--- a/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
+++ b/backend/core-api/src/modules/organization/structure/graphql/schemas/department.ts
@@ -37,13 +37,13 @@ const commonDepartmentParams = `
 `;
 
 export const mutations = `
-    departments(${commonParams},withoutUserFilter:Boolean): [Department]
-    departmentsMain(${commonParams},withoutUserFilter:Boolean): DepartmentsListResponse
-    departmentDetail(_id: String!): Department
-`;
-
-export const queries = `
     departmentsAdd(${commonDepartmentParams}): Department
     departmentsEdit(_id: String!,${commonDepartmentParams}): Department
     departmentsRemove(ids: [String!]): JSON
+`;
+
+export const queries = `
+    departments(${commonParams},withoutUserFilter:Boolean): [Department]
+    departmentsMain(${commonParams},withoutUserFilter:Boolean): DepartmentsListResponse
+    departmentDetail(_id: String!): Department
 `;


### PR DESCRIPTION
…eries
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update query logic for `Department` and `Structures` in GraphQL schema, moving department queries to correct section and adding structures queries.
> 
>   - **GraphQL Schema Updates**:
>     - Add `structuresQueries` to `queries` in `schema.ts`.
>     - Move `departments`, `departmentsMain`, and `departmentDetail` from `mutations` to `queries` in `department.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 7f8c69b43d5e6f7e86b2263614f6f844fb7b09fe. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the categorization of department-related GraphQL operations, ensuring data retrieval actions are now accessible as queries and data modification actions remain as mutations.

- **Chores**
  - Integrated structure-related queries into the main GraphQL schema, expanding available query options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->