### PR TITLE
integration type

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/inbox/components/InboxMainFilter.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/components/InboxMainFilter.tsx
@@ -1,8 +1,8 @@
 import { IconUserFilled, IconUserUp } from '@tabler/icons-react';
 import { Button, Collapsible, ScrollArea } from 'erxes-ui';
 import { ChooseChannel } from '@/inbox/channel/components/ChooseChannel';
-import { ChooseIntegration } from '@/integrations/components/ChooseIntegration';
 import { useMultiQueryState } from 'erxes-ui';
+import { ChooseIntegrationType } from '@/integrations/components/ChooseIntegrationType';
 
 export const InboxMainFilter = () => {
   const [, setQueryStates] = useMultiQueryState<{
@@ -47,7 +47,7 @@ export const InboxMainFilter = () => {
             Assigned to me
           </Button>
           <ChooseChannel />
-          <ChooseIntegration />
+          <ChooseIntegrationType />
         </Collapsible.Content>
       </Collapsible>
     </ScrollArea>

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/FilterTags.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/components/FilterTags.tsx
@@ -1,9 +1,9 @@
 import { Button } from 'erxes-ui';
 import { useMultiQueryState, useQueryState } from 'erxes-ui';
 import { ChannelTag } from '@/inbox/channel/components/ChannelTag';
-import { IntegrationTag } from '@/integrations/components/IntegrationTag';
 import { IconX } from '@tabler/icons-react';
 import { BOOLEAN_FILTERS } from '../../constants/booleanFilters';
+import { IntegrationTypeTag } from '@/integrations/components/IntegrationTypeTag';
 
 export const FilterTags = () => {
   const [{ channelId, integrationType, status }] = useMultiQueryState<{
@@ -19,7 +19,7 @@ export const FilterTags = () => {
       <span className="text-xs text-accent-foreground">Filters:</span>
       <div className="flex flex-wrap gap-2">
         <ChannelTag />
-        <IntegrationTag />
+        <IntegrationTypeTag />
         {status === 'closed' && (
           <FilterTagBoolean label="Resolved" statusKey="status" />
         )}

--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/ChooseIntegrationType.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/ChooseIntegrationType.tsx
@@ -1,0 +1,62 @@
+import { useAtom } from 'jotai';
+import { integrationTypeCollapsibleState } from '../state/integrationCollapsibleState';
+import { Button, Collapsible, Skeleton, useMultiQueryState } from 'erxes-ui';
+import { useUsedIntegrationTypes } from '../hooks/useUsedIntegrationTypes';
+import { IIntegrationType } from '../types/Integration';
+import { IconCheck } from '@tabler/icons-react';
+
+export const ChooseIntegrationType = () => {
+  const [open, setOpen] = useAtom(integrationTypeCollapsibleState);
+
+  return (
+    <Collapsible
+      className="group/integrationType"
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <Collapsible.TriggerButton>
+        <Collapsible.TriggerIcon className="group-data-[state=open]/integrationType:rotate-180" />
+        Integrations
+      </Collapsible.TriggerButton>
+      <Collapsible.Content className="pl-1 flex flex-col gap-1 py-1 overflow-hidden">
+        <ChooseIntegrationTypeContent open={open} />
+      </Collapsible.Content>
+    </Collapsible>
+  );
+};
+
+const ChooseIntegrationTypeContent = ({ open }: { open: boolean }) => {
+  const { integrationTypes, loading } = useUsedIntegrationTypes();
+
+  if (loading) return <Skeleton className="w-32 h-4 mt-1" />;
+
+  return integrationTypes?.map((integrationType: IIntegrationType) => (
+    <IntegrationTypeItem key={integrationType._id} {...integrationType} />
+  ));
+};
+
+export const IntegrationTypeItem = ({ _id, name }: IIntegrationType) => {
+  const [{ integrationType }, setValues] = useMultiQueryState<{
+    integrationType: string;
+    detailView: boolean;
+  }>(['integrationType', 'detailView']);
+
+  const isActive = integrationType === _id;
+
+  const handleClick = () =>
+    setValues({
+      integrationType: _id,
+      detailView: true,
+    });
+
+  return (
+    <Button
+      variant={isActive ? 'secondary' : 'ghost'}
+      className="justify-start pl-7 relative overflow-hidden text-left flex-auto"
+      onClick={handleClick}
+    >
+      {isActive && <IconCheck className="absolute left-1.5" />}
+      {name}
+    </Button>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationTypeTag.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/components/IntegrationTypeTag.tsx
@@ -1,0 +1,58 @@
+import {
+  Combobox,
+  Command,
+  Filter,
+  Popover,
+  Skeleton,
+  TextOverflowTooltip,
+  useQueryState,
+} from 'erxes-ui';
+import { useUsedIntegrationTypes } from '../hooks/useUsedIntegrationTypes';
+import { IIntegrationType } from '../types/Integration';
+
+export const IntegrationTypeTag = () => {
+  const [integrationTypeId, setIntegrationTypeId] =
+    useQueryState<string>('integrationType');
+  const { integrationTypes, loading } = useUsedIntegrationTypes();
+
+  const integrationType = integrationTypes?.find(
+    (integrationType: IIntegrationType) =>
+      integrationType._id === integrationTypeId,
+  );
+
+  if (!integrationType) return null;
+
+  if (loading) {
+    return <Skeleton className="w-20 h-4" />;
+  }
+
+  return (
+    <Filter.BarItem>
+      <Popover>
+        <Popover.Trigger asChild>
+          <Filter.BarButton>{integrationType.name}</Filter.BarButton>
+        </Popover.Trigger>
+        <Combobox.Content>
+          <Command>
+            <Command.Input placeholder="Select integration" />
+            <Command.List>
+              {integrationTypes?.map((integrationType: IIntegrationType) => (
+                <Command.Item
+                  value={integrationType._id}
+                  key={integrationType._id}
+                  onSelect={() => setIntegrationTypeId(integrationType._id)}
+                >
+                  <TextOverflowTooltip value={integrationType.name} />
+                  <Combobox.Check
+                    checked={integrationType._id === integrationTypeId}
+                  />
+                </Command.Item>
+              ))}
+            </Command.List>
+          </Command>
+        </Combobox.Content>
+      </Popover>
+      <Filter.BarClose filterKey="integrationType" />
+    </Filter.BarItem>
+  );
+};

--- a/frontend/plugins/frontline_ui/src/modules/integrations/graphql/queries/getIntegrations.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/graphql/queries/getIntegrations.ts
@@ -44,3 +44,12 @@ export const GET_INTEGRATIONS_BY_KIND = gql`
     }
   }
 `;
+
+export const GET_INTEGRATION_TYPES = gql`
+  query IntegrationsGetUsedTypes {
+    integrationsGetUsedTypes {
+      _id
+      name
+    }
+  }
+`;

--- a/frontend/plugins/frontline_ui/src/modules/integrations/hooks/useUsedIntegrationTypes.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/hooks/useUsedIntegrationTypes.tsx
@@ -1,0 +1,11 @@
+import { useQuery } from '@apollo/client';
+import { GET_INTEGRATION_TYPES } from '../graphql/queries/getIntegrations';
+
+export const useUsedIntegrationTypes = () => {
+  const { data, loading } = useQuery(GET_INTEGRATION_TYPES);
+
+  return {
+    integrationTypes: data?.integrationsGetUsedTypes || [],
+    loading,
+  };
+};

--- a/frontend/plugins/frontline_ui/src/modules/integrations/state/integrationCollapsibleState.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/state/integrationCollapsibleState.tsx
@@ -4,3 +4,8 @@ export const integrationCollapsibleState = atomWithStorage(
   'integrationCollapsibleState',
   false,
 );
+
+export const integrationTypeCollapsibleState = atomWithStorage(
+  'integrationTypeCollapsibleState',
+  false,
+);

--- a/frontend/plugins/frontline_ui/src/modules/integrations/types/Integration.ts
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/types/Integration.ts
@@ -12,3 +12,8 @@ export interface IIntegrationDetail extends IIntegration {
     status: 'success' | 'page-token' | 'account-token';
   };
 }
+
+export interface IIntegrationType {
+  _id: string;
+  name: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,135 +661,6 @@ importers:
         specifier: workspace:^
         version: link:../erxes-api-shared
 
-  backend/core-api/dist:
-    dependencies:
-      '@apollo/server':
-        specifier: 4.11.3
-        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
-      '@apollo/subgraph':
-        specifier: 2.10.0
-        version: 2.10.0(graphql@16.10.0)
-      '@babel/preset-env':
-        specifier: 7.26.9
-        version: 7.26.9(@babel/core@7.26.10)
-      '@elastic/elasticsearch':
-        specifier: 7.17.14
-        version: 7.17.14
-      '@preconstruct/cli':
-        specifier: 2.8.12
-        version: 2.8.12
-      '@prettier/sync':
-        specifier: 0.5.5
-        version: 0.5.5(prettier@2.8.8)
-      '@sniptt/guards':
-        specifier: 0.2.0
-        version: 0.2.0
-      '@trpc/client':
-        specifier: 11.0.4
-        version: 11.0.4(@trpc/server@11.0.4(typescript@5.7.3))(typescript@5.7.3)
-      '@trpc/server':
-        specifier: 11.0.4
-        version: 11.0.4(typescript@5.7.3)
-      '@types/babel__preset-env':
-        specifier: 7.10.0
-        version: 7.10.0
-      '@types/graphql':
-        specifier: 14.5.0
-        version: 14.5.0
-      '@types/ioredis':
-        specifier: 5.0.0
-        version: 5.0.0
-      aws-sdk:
-        specifier: 2.1692.0
-        version: 2.1692.0
-      babel-plugin-module-resolver:
-        specifier: 5.0.2
-        version: 5.0.2
-      bcryptjs:
-        specifier: 3.0.2
-        version: 3.0.2
-      bullmq:
-        specifier: 5.40.4
-        version: 5.40.4
-      cookie-parser:
-        specifier: 1.4.7
-        version: 1.4.7
-      cors:
-        specifier: 2.8.5
-        version: 2.8.5
-      dayjs:
-        specifier: 1.11.13
-        version: 1.11.13
-      dotenv:
-        specifier: 16.4.7
-        version: 16.4.7
-      erxes-api-shared:
-        specifier: workspace:^
-        version: link:../../erxes-api-shared
-      express:
-        specifier: 4.21.2
-        version: 4.21.2
-      file-type:
-        specifier: 20.5.0
-        version: 20.5.0
-      form-data:
-        specifier: 4.0.2
-        version: 4.0.2
-      formidable:
-        specifier: 3.5.4
-        version: 3.5.4
-      glob:
-        specifier: 11.0.1
-        version: 11.0.1
-      graphql:
-        specifier: 16.10.0
-        version: 16.10.0
-      graphql-redis-subscriptions:
-        specifier: 2.7.0
-        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
-      graphql-subscriptions:
-        specifier: 3.0.0
-        version: 3.0.0(graphql@16.10.0)
-      graphql-tag:
-        specifier: 2.12.6
-        version: 2.12.6(graphql@16.10.0)
-      ioredis:
-        specifier: 5.6.1
-        version: 5.6.1
-      jimp:
-        specifier: 1.6.0
-        version: 1.6.0
-      jsonwebtoken:
-        specifier: 9.0.2
-        version: 9.0.2
-      moment:
-        specifier: 2.30.1
-        version: 2.30.1
-      mongoose:
-        specifier: 8.13.2
-        version: 8.13.2
-      nanoid:
-        specifier: 3.3.11
-        version: 3.3.11
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0(encoding@0.1.13)
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
-      underscore:
-        specifier: 1.13.7
-        version: 1.13.7
-      validator:
-        specifier: 13.15.0
-        version: 13.15.0
-      xss:
-        specifier: 1.0.15
-        version: 1.0.15
-      zod:
-        specifier: 3.24.2
-        version: 3.24.2
-
   backend/erxes-api-shared:
     dependencies:
       '@apollo/server':
@@ -899,147 +770,6 @@ importers:
         specifier: workspace:^
         version: link:../erxes-api-shared
 
-  backend/gateway/dist:
-    dependencies:
-      '@apollo/client':
-        specifier: 3.13.8
-        version: 3.13.8(@types/react@18.3.1)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@apollo/server':
-        specifier: 4.12.0
-        version: 4.12.0(encoding@0.1.13)(graphql@16.10.0)
-      '@babel/preset-env':
-        specifier: 7.26.9
-        version: 7.26.9(@babel/core@7.26.10)
-      '@bull-board/api':
-        specifier: 6.9.2
-        version: 6.9.2(@bull-board/ui@6.9.2)
-      '@bull-board/express':
-        specifier: 6.9.2
-        version: 6.9.2
-      '@elastic/elasticsearch':
-        specifier: 7.17.14
-        version: 7.17.14
-      '@envelop/core':
-        specifier: 5.2.3
-        version: 5.2.3
-      '@escape.tech/graphql-armor-character-limit':
-        specifier: 2.3.0
-        version: 2.3.0
-      '@escape.tech/graphql-armor-max-aliases':
-        specifier: 2.6.1
-        version: 2.6.1
-      '@escape.tech/graphql-armor-max-depth':
-        specifier: 2.4.0
-        version: 2.4.0
-      '@graphql-tools/schema':
-        specifier: 10.0.23
-        version: 10.0.23(graphql@16.10.0)
-      '@preconstruct/cli':
-        specifier: 2.8.12
-        version: 2.8.12
-      '@prettier/sync':
-        specifier: 0.5.5
-        version: 0.5.5(prettier@2.8.8)
-      '@sniptt/guards':
-        specifier: 0.2.0
-        version: 0.2.0
-      '@trpc/client':
-        specifier: 11.1.0
-        version: 11.1.0(@trpc/server@11.1.0(typescript@5.7.3))(typescript@5.7.3)
-      '@trpc/server':
-        specifier: 11.1.0
-        version: 11.1.0(typescript@5.7.3)
-      '@types/babel__preset-env':
-        specifier: 7.10.0
-        version: 7.10.0
-      '@types/graphql':
-        specifier: 14.5.0
-        version: 14.5.0
-      '@types/ioredis':
-        specifier: 5.0.0
-        version: 5.0.0
-      babel-plugin-module-resolver:
-        specifier: 5.0.2
-        version: 5.0.2
-      bullmq:
-        specifier: 5.49.1
-        version: 5.49.1
-      cookie-parser:
-        specifier: 1.4.7
-        version: 1.4.7
-      cors:
-        specifier: 2.8.5
-        version: 2.8.5
-      dayjs:
-        specifier: 1.11.13
-        version: 1.11.13
-      dotenv:
-        specifier: 16.5.0
-        version: 16.5.0
-      erxes-api-shared:
-        specifier: workspace:^
-        version: link:../../erxes-api-shared
-      express:
-        specifier: 4.21.2
-        version: 4.21.2
-      glob:
-        specifier: 11.0.1
-        version: 11.0.1
-      graphql:
-        specifier: 16.10.0
-        version: 16.10.0
-      graphql-parse-resolve-info:
-        specifier: 4.14.1
-        version: 4.14.1(graphql@16.10.0)
-      graphql-redis-subscriptions:
-        specifier: 2.7.0
-        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
-      graphql-subscriptions:
-        specifier: 3.0.0
-        version: 3.0.0(graphql@16.10.0)
-      graphql-ws:
-        specifier: 5.16.2
-        version: 5.16.2(graphql@16.10.0)
-      http-proxy-middleware:
-        specifier: 3.0.5
-        version: 3.0.5
-      ioredis:
-        specifier: 5.6.1
-        version: 5.6.1
-      jsonwebtoken:
-        specifier: 9.0.2
-        version: 9.0.2
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
-      mongoose:
-        specifier: 8.13.2
-        version: 8.13.2
-      nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0(encoding@0.1.13)
-      react:
-        specifier: 18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
-      ws:
-        specifier: 8.18.2
-        version: 8.18.2
-      yaml:
-        specifier: 2.7.1
-        version: 2.7.1
-      zod:
-        specifier: 3.23.8
-        version: 3.23.8
-
   backend/plugins/accounting_api:
     dependencies:
       erxes-api-shared:
@@ -1069,126 +799,6 @@ importers:
       strip-html:
         specifier: ^1.0.2
         version: 1.0.2
-
-  backend/plugins/frontline_api/dist:
-    dependencies:
-      '@apollo/server':
-        specifier: 4.11.3
-        version: 4.11.3(encoding@0.1.13)(graphql@16.10.0)
-      '@apollo/subgraph':
-        specifier: 2.10.0
-        version: 2.10.0(graphql@16.10.0)
-      '@babel/preset-env':
-        specifier: 7.26.9
-        version: 7.26.9(@babel/core@7.26.10)
-      '@elastic/elasticsearch':
-        specifier: 7.17.14
-        version: 7.17.14
-      '@preconstruct/cli':
-        specifier: 2.8.12
-        version: 2.8.12
-      '@prettier/sync':
-        specifier: 0.5.5
-        version: 0.5.5(prettier@2.8.8)
-      '@sniptt/guards':
-        specifier: 0.2.0
-        version: 0.2.0
-      '@trpc/client':
-        specifier: 11.0.4
-        version: 11.0.4(@trpc/server@11.0.4(typescript@5.7.3))(typescript@5.7.3)
-      '@trpc/server':
-        specifier: 11.0.4
-        version: 11.0.4(typescript@5.7.3)
-      '@types/babel__preset-env':
-        specifier: 7.10.0
-        version: 7.10.0
-      '@types/graphql':
-        specifier: 14.5.0
-        version: 14.5.0
-      '@types/ioredis':
-        specifier: 5.0.0
-        version: 5.0.0
-      aws-sdk:
-        specifier: ^2.1692.0
-        version: 2.1692.0
-      babel-plugin-module-resolver:
-        specifier: 5.0.2
-        version: 5.0.2
-      bullmq:
-        specifier: 5.40.4
-        version: 5.40.4
-      cookie-parser:
-        specifier: 1.4.7
-        version: 1.4.7
-      cors:
-        specifier: 2.8.5
-        version: 2.8.5
-      dayjs:
-        specifier: 1.11.13
-        version: 1.11.13
-      debug:
-        specifier: ^4.4.0
-        version: 4.4.0(supports-color@5.5.0)
-      dompurify:
-        specifier: 3.2.5
-        version: 3.2.5
-      dotenv:
-        specifier: 16.4.7
-        version: 16.4.7
-      erxes-api-shared:
-        specifier: workspace:^
-        version: link:../../../erxes-api-shared
-      express:
-        specifier: 4.21.2
-        version: 4.21.2
-      fbgraph:
-        specifier: ^1.4.4
-        version: 1.4.4
-      glob:
-        specifier: 11.0.1
-        version: 11.0.1
-      graphql:
-        specifier: 16.10.0
-        version: 16.10.0
-      graphql-redis-subscriptions:
-        specifier: 2.7.0
-        version: 2.7.0(graphql-subscriptions@3.0.0(graphql@16.10.0))
-      graphql-subscriptions:
-        specifier: 3.0.0
-        version: 3.0.0(graphql@16.10.0)
-      graphql-tag:
-        specifier: 2.12.6
-        version: 2.12.6(graphql@16.10.0)
-      moment:
-        specifier: 2.30.1
-        version: 2.30.1
-      moment-timezone:
-        specifier: ^0.5.48
-        version: 0.5.48
-      mongoose:
-        specifier: 8.13.2
-        version: 8.13.2
-      nanoid:
-        specifier: 3.3.11
-        version: 3.3.11
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0(encoding@0.1.13)
-      string-strip-html:
-        specifier: ^13.4.12
-        version: 13.4.12
-      strip-ansi:
-        specifier: 7.1.0
-        version: 7.1.0
-      strip-html:
-        specifier: ^1.0.2
-        version: 1.0.2
-      underscore:
-        specifier: 1.13.7
-        version: 1.13.7
-      zod:
-        specifier: 3.24.2
-        version: 3.24.2
 
   backend/plugins/pos_api:
     dependencies:
@@ -1275,24 +885,6 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
-  '@apollo/client@3.13.8':
-    resolution: {integrity: sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==}
-    peerDependencies:
-      graphql: ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5 || ^6.0.3
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-    peerDependenciesMeta:
-      graphql-ws:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      subscriptions-transport-ws:
-        optional: true
-
   '@apollo/federation-internals@2.10.0':
     resolution: {integrity: sha512-IneWuwDc9ozKLcEsKw7YEkhzo7VAa54RjKwAVEqPFHPVqUjIYUKX99gSWAp9ZQeI8DGrz2a8uKEDlKGOHh3UaA==}
     engines: {node: '>=14.15.0'}
@@ -1315,12 +907,6 @@ packages:
 
   '@apollo/server@4.11.3':
     resolution: {integrity: sha512-mW8idE2q0/BN14mimfJU5DAnoPHZRrAWgwsVLBEdACds+mxapIYxIbI6AH4AsOpxfrpvHts3PCYDbopy1XPW1g==}
-    engines: {node: '>=14.16.0'}
-    peerDependencies:
-      graphql: ^16.6.0
-
-  '@apollo/server@4.12.0':
-    resolution: {integrity: sha512-Z5RNTCnIia+dFsP5HW2ugQMrIOWgyNWyKP+jMVXthp/ECjYyyRYPC41ukCDwxHQY4vNZ3rgbgqroWVQUGFt2gA==}
     engines: {node: '>=14.16.0'}
     peerDependencies:
       graphql: ^16.6.0
@@ -2057,22 +1643,11 @@ packages:
     peerDependencies:
       '@bull-board/ui': 6.9.0
 
-  '@bull-board/api@6.9.2':
-    resolution: {integrity: sha512-cWnOl6taWHSHadHjRoCRBwatIb68DahvD/Fko4RP6bvOqbmIRF6FeuBOqJ6OOEceTvROqvh3Nn96tAksnicB6g==}
-    peerDependencies:
-      '@bull-board/ui': 6.9.2
-
   '@bull-board/express@6.9.0':
     resolution: {integrity: sha512-TH1NDYtl058aZVR+roEzJ+oK9sHXlg0ypeZHeqjBfdttCR0YQdAkyElfilHTdOwElPTJntwxGYVhXWajtCskcw==}
 
-  '@bull-board/express@6.9.2':
-    resolution: {integrity: sha512-Gc5LwdLQeOcP85hcZyQ8s3+gpqkiN32oK3/exbxBWaaQ4lXH6DvbAsImOmY/qk4VFGV4wiuCwajghqG057IFFw==}
-
   '@bull-board/ui@6.9.0':
     resolution: {integrity: sha512-PbMswtthSAyYHhV+/kIkDPStgv2JKIC6frhXW/doTuhaQGCnggA080kiysz4e7omYP8SCBApuKBeVmc2bxfhWA==}
-
-  '@bull-board/ui@6.9.2':
-    resolution: {integrity: sha512-vRIUat5JM39TR38YSnEresCFDMxvJMfBmAD9zQjS4xiwHtlRqNjY7fGIKWb9Agq0gQzSvYqOo2bPqz7pO0hOBw==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2718,10 +2293,6 @@ packages:
 
   '@escape.tech/graphql-armor-max-aliases@2.6.0':
     resolution: {integrity: sha512-9dwRC5+dl986byBD9QRYRUrLALa7awpUe4aIM1j7StZHGJgmYRj3LZaWQM3JyI8j2FXg4rqBC4FJAiVYpRyWqw==}
-    engines: {node: '>=18.0.0'}
-
-  '@escape.tech/graphql-armor-max-aliases@2.6.1':
-    resolution: {integrity: sha512-R6DJqGXsWSv/rqM5loAZUTIY42XqCebaKG1irdK6uWxoQXywyrscqfJklh2u8/yLYz2gl2WPzzdYWMWEueMN5w==}
     engines: {node: '>=18.0.0'}
 
   '@escape.tech/graphql-armor-max-depth@2.4.0':
@@ -5345,19 +4916,8 @@ packages:
       '@trpc/server': 11.0.4
       typescript: '>=5.7.2'
 
-  '@trpc/client@11.1.0':
-    resolution: {integrity: sha512-Q3pL4p7AddxI/ZJTEFo1utKSdasDFjZPECIPsKDkthEt52k530JkYVltTdLkYFKrNWXKKBo8MN7NwchelczoRw==}
-    peerDependencies:
-      '@trpc/server': 11.1.0
-      typescript: '>=5.7.2'
-
   '@trpc/server@11.0.4':
     resolution: {integrity: sha512-beDEGEw+slNiYxLUpZ8HKU1mnZBoP/VLMtrKh2ABKl7VC0PQV9XcDMVjB0GcSW15nTSiOnGDGyFDeudp4dH2qw==}
-    peerDependencies:
-      typescript: '>=5.7.2'
-
-  '@trpc/server@11.1.0':
-    resolution: {integrity: sha512-uAJ7ikejeujVkf53XFJ/0W8nr7bDjul+Szk5Rsepq97Hb/WS1RkRXdyX4KqAyCE9b1vDFCJVJwSxiIZdRtbTZQ==}
     peerDependencies:
       typescript: '>=5.7.2'
 
@@ -6457,9 +6017,6 @@ packages:
 
   bullmq@5.40.4:
     resolution: {integrity: sha512-MaIOhc31ZbVi9HbY0VAalsXoywelzEPNr6dojoKSMCXDnEVTQ27LkT5LA0Mlpr7ZunMLfpH94SLYrWNsPMsQrg==}
-
-  bullmq@5.49.1:
-    resolution: {integrity: sha512-tui5dgCZjL0LA5GTFhvuvcLxZnhfkptK/6xs7H/DnhFMgriXerHhwNphCb9Bs/0IuXaM1FabD9tFaNmDqHL0XA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -10361,11 +9918,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -13702,29 +13254,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@apollo/client@3.13.8(@types/react@18.3.1)(graphql-ws@5.16.2(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
-      '@wry/caches': 1.0.1
-      '@wry/equality': 0.5.7
-      '@wry/trie': 0.5.0
-      graphql: 16.10.0
-      graphql-tag: 2.12.6(graphql@16.10.0)
-      hoist-non-react-statics: 3.3.2
-      optimism: 0.18.1
-      prop-types: 15.8.1
-      rehackt: 0.1.0(@types/react@18.3.1)(react@18.3.1)
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
-      tslib: 2.8.1
-      zen-observable-ts: 1.2.5
-    optionalDependencies:
-      graphql-ws: 5.16.2(graphql@16.10.0)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@apollo/federation-internals@2.10.0(graphql@16.10.0)':
     dependencies:
       '@types/uuid': 9.0.8
@@ -13767,37 +13296,6 @@ snapshots:
       graphql: 16.10.0
 
   '@apollo/server@4.11.3(encoding@0.1.13)(graphql@16.10.0)':
-    dependencies:
-      '@apollo/cache-control-types': 1.0.3(graphql@16.10.0)
-      '@apollo/server-gateway-interface': 1.1.1(graphql@16.10.0)
-      '@apollo/usage-reporting-protobuf': 4.1.1
-      '@apollo/utils.createhash': 2.0.2
-      '@apollo/utils.fetcher': 2.0.1
-      '@apollo/utils.isnodelike': 2.0.1
-      '@apollo/utils.keyvaluecache': 2.1.1
-      '@apollo/utils.logger': 2.0.1
-      '@apollo/utils.usagereporting': 2.1.0(graphql@16.10.0)
-      '@apollo/utils.withrequired': 2.0.1
-      '@graphql-tools/schema': 9.0.19(graphql@16.10.0)
-      '@types/express': 4.17.21
-      '@types/express-serve-static-core': 4.19.6
-      '@types/node-fetch': 2.6.12
-      async-retry: 1.3.3
-      cors: 2.8.5
-      express: 4.21.2
-      graphql: 16.10.0
-      loglevel: 1.9.2
-      lru-cache: 7.18.3
-      negotiator: 0.6.4
-      node-abort-controller: 3.1.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-      uuid: 9.0.1
-      whatwg-mimetype: 3.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@apollo/server@4.12.0(encoding@0.1.13)(graphql@16.10.0)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.10.0)
       '@apollo/server-gateway-interface': 1.1.1(graphql@16.10.0)
@@ -14821,11 +14319,6 @@ snapshots:
       '@bull-board/ui': 6.9.0
       redis-info: 3.1.0
 
-  '@bull-board/api@6.9.2(@bull-board/ui@6.9.2)':
-    dependencies:
-      '@bull-board/ui': 6.9.2
-      redis-info: 3.1.0
-
   '@bull-board/express@6.9.0':
     dependencies:
       '@bull-board/api': 6.9.0(@bull-board/ui@6.9.0)
@@ -14835,22 +14328,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@bull-board/express@6.9.2':
-    dependencies:
-      '@bull-board/api': 6.9.2(@bull-board/ui@6.9.2)
-      '@bull-board/ui': 6.9.2
-      ejs: 3.1.10
-      express: 4.21.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@bull-board/ui@6.9.0':
     dependencies:
       '@bull-board/api': 6.9.0(@bull-board/ui@6.9.0)
-
-  '@bull-board/ui@6.9.2':
-    dependencies:
-      '@bull-board/api': 6.9.2(@bull-board/ui@6.9.2)
 
   '@colors/colors@1.5.0':
     optional: true
@@ -15263,13 +14743,6 @@ snapshots:
       '@escape.tech/graphql-armor-types': 0.7.0
 
   '@escape.tech/graphql-armor-max-aliases@2.6.0':
-    dependencies:
-      graphql: 16.10.0
-    optionalDependencies:
-      '@envelop/core': 5.2.3
-      '@escape.tech/graphql-armor-types': 0.7.0
-
-  '@escape.tech/graphql-armor-max-aliases@2.6.1':
     dependencies:
       graphql: 16.10.0
     optionalDependencies:
@@ -19043,16 +18516,7 @@ snapshots:
       '@trpc/server': 11.0.4(typescript@5.7.3)
       typescript: 5.7.3
 
-  '@trpc/client@11.1.0(@trpc/server@11.1.0(typescript@5.7.3))(typescript@5.7.3)':
-    dependencies:
-      '@trpc/server': 11.1.0(typescript@5.7.3)
-      typescript: 5.7.3
-
   '@trpc/server@11.0.4(typescript@5.7.3)':
-    dependencies:
-      typescript: 5.7.3
-
-  '@trpc/server@11.1.0(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
@@ -20372,18 +19836,6 @@ snapshots:
   builtin-modules@3.3.0: {}
 
   bullmq@5.40.4:
-    dependencies:
-      cron-parser: 4.9.0
-      ioredis: 5.6.1
-      msgpackr: 1.11.2
-      node-abort-controller: 3.1.1
-      semver: 7.7.1
-      tslib: 2.8.1
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  bullmq@5.49.1:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.6.1
@@ -25449,8 +24901,6 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
-
-  nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
## Summary by Sourcery

Add integration type filtering to the frontend inbox UI and regenerate the lockfile

New Features:
- Add GraphQL query GET_INTEGRATION_TYPES and useUsedIntegrationTypes hook to fetch available integration types
- Introduce integrationTypeCollapsibleState atom to manage integration type filter state
- Define IIntegrationType interface for typed integration type data
- Implement ChooseIntegrationType component for selecting integration types in the filter panel
- Implement IntegrationTypeTag component to display and manage the active integration type filter
- Update InboxMainFilter and FilterTags components to use the new integration type filter components

Chores:
- Regenerate and clean up pnpm-lock.yaml by removing outdated dist dependency entries