### PR TITLE
Fb login url

### DIFF
--- a/backend/erxes-api-shared/src/utils/graphqlPubSub.ts
+++ b/backend/erxes-api-shared/src/utils/graphqlPubSub.ts
@@ -5,7 +5,7 @@ import Redis from 'ioredis';
 // load environment variables
 dotenv.config();
 
-const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD } = process.env;
+const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, SKIP_REDIS } = process.env;
 
 const redisOptions = {
   host: REDIS_HOST,

--- a/backend/erxes-api-shared/src/utils/graphqlPubSub.ts
+++ b/backend/erxes-api-shared/src/utils/graphqlPubSub.ts
@@ -1,28 +1,28 @@
 import * as dotenv from 'dotenv';
-dotenv.config();
 import { RedisPubSub } from 'graphql-redis-subscriptions';
-import { PubSub } from 'graphql-subscriptions';
 import Redis from 'ioredis';
 
-const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, SKIP_REDIS } = process.env;
-const skipRedis = SKIP_REDIS === 'true';
+// load environment variables
+dotenv.config();
 
-export const graphqlPubsub = skipRedis
-  ? new PubSub()
-  : new RedisPubSub({
-      connectionListener: (error) => {
-        if (error) {
-          console.log(error);
-        }
-      },
-      publisher: new Redis({
-        host: REDIS_HOST,
-        port: parseInt(REDIS_PORT || '6379', 10),
-        password: REDIS_PASSWORD,
-      }),
-      subscriber: new Redis({
-        host: REDIS_HOST,
-        port: parseInt(REDIS_PORT || '6379', 10),
-        password: REDIS_PASSWORD,
-      }),
-    });
+const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD } = process.env;
+
+const redisOptions = {
+  host: REDIS_HOST,
+  port: parseInt(REDIS_PORT || '6379', 10),
+  password: REDIS_PASSWORD,
+};
+
+const createPubsubInstance = () => {
+  return new RedisPubSub({
+    connectionListener: (error) => {
+      if (error) {
+        console.error(error);
+      }
+    },
+    publisher: new Redis(redisOptions),
+    subscriber: new Redis(redisOptions),
+  });
+};
+
+export const graphqlPubsub = createPubsubInstance();

--- a/backend/gateway/src/main.ts
+++ b/backend/gateway/src/main.ts
@@ -30,7 +30,7 @@ const domain = process.env.DOMAIN ?? 'http://localhost:3001';
 
 const corsOptions = {
   credentials: true,
-  origin: [domain],
+  origin: ['http://localhost:3001'],
 };
 
 const myQueue = new Queue('gateway-service-discovery', {

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
@@ -87,7 +87,7 @@ export const publishConversationsChanged = async (
   const models = await generateModels(subdomain);
 
   for (const _id of _ids) {
-    graphqlPubsub.publish(`conversationChanged:${_id}`, {
+    await graphqlPubsub.publish(`conversationChanged:${_id}`, {
       conversationChanged: { conversationId: _id, type },
     });
 
@@ -105,7 +105,7 @@ export const publishMessage = async (
   message: any,
   customerId?: string,
 ) => {
-  graphqlPubsub.publish(
+  await graphqlPubsub.publish(
     `conversationMessageInserted:${message.conversationId}`,
     {
       conversationMessageInserted: message,
@@ -118,12 +118,15 @@ export const publishMessage = async (
         message.conversationId,
       );
 
-    graphqlPubsub.publish(`conversationAdminMessageInserted:${customerId}`, {
-      conversationAdminMessageInserted: {
-        customerId,
-        unreadCount,
+    await graphqlPubsub.publish(
+      `conversationAdminMessageInserted:${customerId}`,
+      {
+        conversationAdminMessageInserted: {
+          customerId,
+          unreadCount,
+        },
       },
-    });
+    );
   }
 };
 
@@ -463,7 +466,7 @@ export const conversationMutations = {
         },
       ],
     });
-    await graphqlPubsub.publish(
+    await await graphqlPubsub.publish(
       `conversationMessageInserted:${message.conversationId}`,
       {
         conversationMessageInserted: message,

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
@@ -105,7 +105,7 @@ export const publishMessage = async (
   message: any,
   customerId?: string,
 ) => {
-  await graphqlPubsub.publish(
+  graphqlPubsub.publish(
     `conversationMessageInserted:${message.conversationId}`,
     {
       conversationMessageInserted: message,

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
@@ -87,11 +87,10 @@ export const publishConversationsChanged = async (
   const models = await generateModels(subdomain);
 
   for (const _id of _ids) {
-    await (
-      graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>
-    )(`conversationChanged:${_id}`, {
+    graphqlPubsub.publish(`conversationChanged:${_id}`, {
       conversationChanged: { conversationId: _id, type },
     });
+
     await models.Conversations.findOne({ _id });
   }
 
@@ -106,10 +105,10 @@ export const publishMessage = async (
   message: any,
   customerId?: string,
 ) => {
-  (graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>)(
-    `conversationClientMessageInserted:${message.conversationId}`,
+  graphqlPubsub.publish(
+    `conversationMessageInserted:${message.conversationId}`,
     {
-      conversationClientMessageInserted: message,
+      conversationMessageInserted: message,
     },
   );
 
@@ -119,9 +118,7 @@ export const publishMessage = async (
         message.conversationId,
       );
 
-    await (
-      graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>
-    )(`conversationAdminMessageInserted:${customerId}`, {
+    graphqlPubsub.publish(`conversationAdminMessageInserted:${customerId}`, {
       conversationAdminMessageInserted: {
         customerId,
         unreadCount,
@@ -466,11 +463,12 @@ export const conversationMutations = {
         },
       ],
     });
-    await (
-      graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>
-    )(`conversationClientMessageInserted:${message.conversationId}`, {
-      conversationClientMessageInserted: message,
-    });
+    await graphqlPubsub.publish(
+      `conversationMessageInserted:${message.conversationId}`,
+      {
+        conversationMessageInserted: message,
+      },
+    );
 
     return models.Conversations.updateOne(
       { _id },

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/conversations.ts
@@ -466,7 +466,7 @@ export const conversationMutations = {
         },
       ],
     });
-    await await graphqlPubsub.publish(
+    await graphqlPubsub.publish(
       `conversationMessageInserted:${message.conversationId}`,
       {
         conversationMessageInserted: message,

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
@@ -42,15 +42,18 @@ export const pConversationClientMessageInserted = async (
     console.warn(`Conversation not found for message: ${message._id}`);
     return;
   }
-  graphqlPubsub.publish(`conversationMessageInserted:${conversation._id}`, {
-    conversationMessageInserted: message,
-    subdomain,
-    conversation,
-    integration,
-  });
+  await graphqlPubsub.publish(
+    `conversationMessageInserted:${conversation._id}`,
+    {
+      conversationMessageInserted: message,
+      subdomain,
+      conversation,
+      integration,
+    },
+  );
 
   for (const userId of channelMemberIds) {
-    graphqlPubsub.publish(
+    await graphqlPubsub.publish(
       `conversationClientMessageInserted:${subdomain}:${userId}`,
       {
         conversationClientMessageInserted: message,

--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/mutations/widget.ts
@@ -42,24 +42,22 @@ export const pConversationClientMessageInserted = async (
     console.warn(`Conversation not found for message: ${message._id}`);
     return;
   }
-  (graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>)(
-    `conversationMessageInserted:${conversation._id}`,
-    {
-      conversationMessageInserted: message,
-      subdomain,
-      conversation,
-      integration,
-    },
-  );
+  graphqlPubsub.publish(`conversationMessageInserted:${conversation._id}`, {
+    conversationMessageInserted: message,
+    subdomain,
+    conversation,
+    integration,
+  });
 
   for (const userId of channelMemberIds) {
-    await (
-      graphqlPubsub.publish as (trigger: string, payload: any) => Promise<void>
-    )(`conversationClientMessageInserted:${subdomain}:${userId}`, {
-      conversationClientMessageInserted: message,
-      subdomain,
-      conversation,
-      integration,
-    });
+    graphqlPubsub.publish(
+      `conversationClientMessageInserted:${subdomain}:${userId}`,
+      {
+        conversationClientMessageInserted: message,
+        subdomain,
+        conversation,
+        integration,
+      },
+    );
   }
 };

--- a/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
@@ -190,23 +190,12 @@ export const receiveTrpcMessage = async (
       conversationDoc,
     );
 
-    // FIXME: Find userId and `conversationClientMessageInserted:${userId}`
-    const publish = graphqlPubsub.publish as <T>(
-      trigger: string,
-      payload: T,
-    ) => Promise<void>;
-
-    await publish('conversationClientMessageInserted', {
-      conversationClientMessageInserted: message,
-    });
-
-    await publish(
-      `conversationClientMessageInserted:${message.conversationId}`,
+    graphqlPubsub.publish(
+      `conversationMessageInserted:${message.conversationId}`,
       {
-        conversationClientMessageInserted: message,
+        conversationMessageInserted: message,
       },
     );
-
     return sendSuccess({ _id: message._id });
   }
 
@@ -244,27 +233,22 @@ export const receiveIntegrationsNotification = async (subdomain, msg) => {
 
   const models = await generateModels(subdomain);
 
-  const publish = graphqlPubsub.publish as <T>(
-    trigger: string,
-    payload: T,
-  ) => Promise<void>;
-
   if (action === 'external-integration-entry-added') {
-    await publish('conversationExternalIntegrationMessageInserted', {});
+    graphqlPubsub.publish('conversationExternalIntegrationMessageInserted', {});
 
     if (conversationId) {
       await models.Conversations.reopen(conversationId);
       // FIXME: It must have _id
-      await pConversationClientMessageInserted(subdomain, {
-        _id: conversationId,
-      });
+      // await pConversationClientMessageInserted(models, subdomain, {
+      //   conversationId,
+      // });
     }
 
     return sendSuccess({ status: 'ok' });
   }
 
   if (action === 'sync-calendar-event') {
-    await publish('calendarEventUpdated', {});
+    graphqlPubsub.publish('calendarEventUpdated', {});
 
     return sendSuccess({ status: 'ok' });
   }

--- a/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/receiveMessage.ts
@@ -190,7 +190,7 @@ export const receiveTrpcMessage = async (
       conversationDoc,
     );
 
-    graphqlPubsub.publish(
+    await graphqlPubsub.publish(
       `conversationMessageInserted:${message.conversationId}`,
       {
         conversationMessageInserted: message,
@@ -234,7 +234,10 @@ export const receiveIntegrationsNotification = async (subdomain, msg) => {
   const models = await generateModels(subdomain);
 
   if (action === 'external-integration-entry-added') {
-    graphqlPubsub.publish('conversationExternalIntegrationMessageInserted', {});
+    await graphqlPubsub.publish(
+      'conversationExternalIntegrationMessageInserted',
+      {},
+    );
 
     if (conversationId) {
       await models.Conversations.reopen(conversationId);
@@ -248,7 +251,7 @@ export const receiveIntegrationsNotification = async (subdomain, msg) => {
   }
 
   if (action === 'sync-calendar-event') {
-    graphqlPubsub.publish('calendarEventUpdated', {});
+    await graphqlPubsub.publish('calendarEventUpdated', {});
 
     return sendSuccess({ status: 'ok' });
   }

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
@@ -121,7 +121,7 @@ export const receiveMessage = async (
 
         await pConversationClientMessageInserted(subdomain, doc);
 
-        graphqlPubsub.publish(
+        await graphqlPubsub.publish(
           `conversationMessageInserted:${conversation.erxesApiId}`,
           {
             conversationMessageInserted: {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/receiveMessage.ts
@@ -121,15 +121,10 @@ export const receiveMessage = async (
 
         await pConversationClientMessageInserted(subdomain, doc);
 
-        const publish = graphqlPubsub.publish as <T>(
-          trigger: string,
-          payload: T,
-        ) => Promise<void>;
-
-        await publish(
-          `conversationClientMessageInserted:${conversation.erxesApiId}`,
+        graphqlPubsub.publish(
+          `conversationMessageInserted:${conversation.erxesApiId}`,
           {
-            conversationClientMessageInserted: {
+            conversationMessageInserted: {
               ...created.toObject(),
               conversationId: conversation.erxesApiId,
             },

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
@@ -209,7 +209,7 @@ export const getOrCreateComment = async (
     };
     await pConversationClientMessageInserted(subdomain, doc);
 
-    graphqlPubsub.publish(
+    await graphqlPubsub.publish(
       `conversationMessageInserted:${conversation.erxesApiId}`,
       {
         conversationMessageInserted: {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
@@ -209,15 +209,10 @@ export const getOrCreateComment = async (
     };
     await pConversationClientMessageInserted(subdomain, doc);
 
-    const publish = graphqlPubsub.publish as <T>(
-      trigger: string,
-      payload: T,
-    ) => Promise<void>;
-
-    await publish(
-      `conversationClientMessageInserted:${conversation.erxesApiId}`,
+    graphqlPubsub.publish(
+      `conversationMessageInserted:${conversation.erxesApiId}`,
       {
-        conversationClientMessageInserted: {
+        conversationMessageInserted: {
           ...conversation?.toObject(),
           conversationId: conversation.erxesApiId,
         },

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/helpers.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/helpers.ts
@@ -82,10 +82,10 @@ export const removeIntegration = async (
   const ENDPOINT_URL = getEnv({ name: 'ENDPOINT_URL' });
   const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });
 
-  let domain = `${DOMAIN}/gateway/pl:facebook`;
+  let domain = `${DOMAIN}/gateway/pl:frontline`;
 
   if (process.env.NODE_ENV !== 'production') {
-    domain = `${DOMAIN}/pl:facebook`;
+    domain = `${DOMAIN}/pl:frontline`;
   }
 
   if (ENDPOINT_URL) {
@@ -178,10 +178,10 @@ export const repairIntegrations = async (
   const ENDPOINT_URL = getEnv({ name: 'ENDPOINT_URL' });
   const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });
 
-  let domain = `${DOMAIN}/gateway/pl:facebook`;
+  let domain = `${DOMAIN}/gateway/pl:frontline`;
 
   if (process.env.NODE_ENV !== 'production') {
-    domain = `${DOMAIN}/pl:facebook`;
+    domain = `${DOMAIN}/pl:frontline`;
   }
 
   if (ENDPOINT_URL) {
@@ -292,10 +292,10 @@ export const facebookCreateIntegration = async (
   const ENDPOINT_URL = getEnv({ name: 'ENDPOINT_URL' });
   const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });
 
-  let domain = `${DOMAIN}/gateway/pl:facebook`;
+  let domain = `${DOMAIN}/gateway/pl:frontline`;
 
   if (process.env.NODE_ENV !== 'production') {
-    domain = `${DOMAIN}/pl:facebook`;
+    domain = `${DOMAIN}/pl:frontline`;
   }
 
   if (ENDPOINT_URL) {

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
@@ -28,7 +28,7 @@ export const loginMiddleware = async (req, res) => {
   const FACEBOOK_LOGIN_REDIRECT_URL = await getConfig(
     models,
     'FACEBOOK_LOGIN_REDIRECT_URL',
-    `${API_DOMAIN}/pl:facebook/fblogin`,
+    `${API_DOMAIN}/pl:frontline/facebook/fblogin`,
   );
   const conf = {
     client_id: FACEBOOK_APP_ID,
@@ -45,7 +45,7 @@ export const loginMiddleware = async (req, res) => {
       client_id: conf.client_id,
       redirect_uri: conf.redirect_uri,
       scope: conf.scope,
-      state: `${API_DOMAIN}/pl:facebook`,
+      state: `${API_DOMAIN}/pl:frontline/facebook`,
     });
 
     // checks whether a user denied the app facebook login/permissions

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/loginMiddleware.ts
@@ -23,21 +23,19 @@ export const loginMiddleware = async (req, res) => {
     'pages_messaging,pages_manage_ads,pages_manage_engagement,pages_manage_metadata,pages_read_user_content',
   );
 
-  const DOMAIN = getEnv({ name: 'DOMAIN' });
-
+  const DOMAIN = getEnv({ name: 'DOMAIN', subdomain });
+  const API_DOMAIN = DOMAIN.includes('zrok') ? DOMAIN : `${DOMAIN}/gateway`;
   const FACEBOOK_LOGIN_REDIRECT_URL = await getConfig(
     models,
     'FACEBOOK_LOGIN_REDIRECT_URL',
-    `${DOMAIN}/gateway/pl:facebook/fblogin`,
+    `${API_DOMAIN}/pl:facebook/fblogin`,
   );
-
   const conf = {
     client_id: FACEBOOK_APP_ID,
     client_secret: FACEBOOK_APP_SECRET,
     scope: FACEBOOK_PERMISSIONS,
     redirect_uri: FACEBOOK_LOGIN_REDIRECT_URL,
   };
-
   debugRequest(debugFacebook, req);
 
   // we don't have a code yet
@@ -47,41 +45,32 @@ export const loginMiddleware = async (req, res) => {
       client_id: conf.client_id,
       redirect_uri: conf.redirect_uri,
       scope: conf.scope,
-      state: `${DOMAIN}/gateway/pl:facebook`,
+      state: `${API_DOMAIN}/pl:facebook`,
     });
+
     // checks whether a user denied the app facebook login/permissions
     if (!req.query.error) {
       debugResponse(debugFacebook, req, authUrl);
-      return await res.redirect(authUrl);
+      return res.redirect(authUrl);
     } else {
       debugResponse(debugFacebook, req, 'access denied');
       return res.send('access denied');
     }
   }
+
   const config = {
     client_id: conf.client_id,
     redirect_uri: conf.redirect_uri,
     client_secret: conf.client_secret,
     code: req.query.code,
   };
-
   debugResponse(debugFacebook, req, JSON.stringify(config));
+  // If this branch executes user is already being redirected back with
+  // code (whatever that is)
+  // code is set
+  // we'll send that and get the access token
 
   return graph.authorize(config, async (_err, facebookRes) => {
-    if (_err) {
-      console.error('Facebook authorization error:', _err);
-      return res.status(500).json({
-        error: 'Failed to authenticate with Facebook',
-        details:
-          process.env.NODE_ENV === 'development' ? _err.message : undefined,
-      });
-    }
-
-    if (!facebookRes?.access_token) {
-      return res.status(400).json({
-        error: 'Invalid Facebook authorization response',
-      });
-    }
     const { access_token } = facebookRes;
 
     const userAccount: {
@@ -92,9 +81,7 @@ export const loginMiddleware = async (req, res) => {
       'me?fields=id,first_name,last_name',
       access_token,
     );
-
     const name = `${userAccount.first_name} ${userAccount.last_name}`;
-
     const account = await models.FacebookAccounts.findOne({
       uid: userAccount.id,
     });
@@ -104,10 +91,10 @@ export const loginMiddleware = async (req, res) => {
         { _id: account._id },
         { $set: { token: access_token } },
       );
-
       const integrations = await models.FacebookIntegrations.find({
         accountId: account._id,
       });
+
       for (const integration of integrations) {
         await repairIntegrations(subdomain, models, integration.erxesApiId);
       }
@@ -120,8 +107,10 @@ export const loginMiddleware = async (req, res) => {
       });
     }
 
-    const url = `${DOMAIN}/settings/fb-authorization?fbAuthorized=true`;
-
+    const reactAppUrl = !DOMAIN.includes('zrok')
+      ? DOMAIN
+      : 'http://localhost:3001';
+    const url = `${reactAppUrl}/settings/fb-authorization?fbAuthorized=true`;
     debugResponse(debugFacebook, req, url);
 
     return res.redirect(url);

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/inboxSubscriptions.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/inboxSubscriptions.ts
@@ -1,6 +1,22 @@
 import { gql } from '@apollo/client';
 import { ATTACHMENT_GQL } from 'erxes-ui';
+import messageFields from './messageFields';
 
+export const conversationChanged = gql`
+  subscription conversationChanged($_id: String!) {
+    conversationChanged(_id: $_id) {
+      type
+    }
+  }
+`;
+
+export const conversationMessageInserted = gql`
+  subscription conversationMessageInserted($_id: String!) {
+    conversationMessageInserted(_id: $_id) {
+      ${messageFields}
+    }
+  }
+`;
 export const CONVERSATION_CHANGED = gql`
   subscription conversationChanged($_id: String!) {
     conversationChanged(_id: $_id) {
@@ -58,6 +74,8 @@ const customerConnectionChanged = `
 `;
 
 export default {
+  conversationChanged,
+  conversationMessageInserted,
   conversationClientMessageInserted,
   conversationClientTypingStatusChanged,
   conversationExternalIntegrationMessageInserted,

--- a/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/messageFields.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/conversations/graphql/subscriptions/messageFields.ts
@@ -1,0 +1,90 @@
+export default `
+  _id
+  content
+  attachments {
+    url
+    name
+    size
+    type
+  }
+  mentionedUserIds
+  conversationId
+
+
+  internal
+  fromBot
+  contentType
+  customerId
+  userId
+  createdAt
+  isCustomerRead
+  formWidgetData
+  messengerAppData
+  botData
+  user {
+    _id
+    username
+    details {
+      avatar
+      fullName
+      position
+    }
+  }
+      customer {
+        _id
+        avatar
+        firstName
+        middleName
+        lastName
+        primaryEmail
+        primaryPhone
+        state
+        companies {
+          _id
+          primaryName
+          website
+        }
+
+        customFieldsData
+
+        tagIds
+        getTags {
+          _id
+          name
+          colorCode
+        }
+      }
+  mailData {
+    messageId
+    threadId
+    subject
+    body
+    integrationEmail
+    to {
+      email
+    }
+    from {
+      email
+    }
+    cc {
+      email
+    }
+    bcc {
+      email
+    }
+    accountId
+    replyToMessageId
+    replyTo
+    references
+    inReplyTo
+    headerId
+    attachments {
+      id
+      content_type
+      filename
+      mimeType
+      size
+      attachmentId
+    }
+  }
+`;


### PR DESCRIPTION
## Summary by Sourcery

Refactor GraphQL pubsub setup to always use a RedisPubSub instance and simplify instantiation; rename subscription triggers and payload keys from "conversationClientMessageInserted" to "conversationMessageInserted" and streamline publish calls; introduce a reusable messageFields fragment and add a new conversationMessageInserted subscription in the frontend; update Facebook login flow to use pl:frontline URLs with a dynamic API_DOMAIN and correct post-login redirect to the React app; restrict gateway CORS origin to localhost for development

New Features:
- Introduce a shared messageFields GraphQL fragment and expose a conversationMessageInserted subscription in the frontend

Enhancements:
- Unify Redis pubsub creation in graphqlPubSub util and remove SKIP_REDIS fallback
- Standardize publish triggers and payloads by renaming to conversationMessageInserted across backend resolvers and controllers
- Streamline GraphQL publish calls by removing type assertions and ensuring proper async/await usage
- Update Facebook integration middleware and helpers to use pl:frontline endpoints and a dynamic API_DOMAIN for login and redirect flows

Chores:
- Restrict gateway CORS origin to localhost for frontend development