### PR TITLE
chore: remove lucide

### DIFF
--- a/frontend/core-ui/src/modules/automations/components/builder/AutomationBuilderSidebar.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/AutomationBuilderSidebar.tsx
@@ -14,7 +14,7 @@ import {
   TablerIcon,
   cn,
 } from 'erxes-ui';
-import { Search } from 'lucide-react';
+import { IconSearch } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ConstantsQueryResponse } from '../../types';
@@ -136,7 +136,7 @@ const Default = () => {
       <div className="p-4 border-b">
         <h3 className="font-medium mb-3">Workflow Components</h3>
         <div className="relative flex items-center">
-          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <IconSearch className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
             placeholder="Search components..."
             className="pl-8"

--- a/frontend/core-ui/src/modules/automations/components/builder/nodes/NodeActions.tsx
+++ b/frontend/core-ui/src/modules/automations/components/builder/nodes/NodeActions.tsx
@@ -1,6 +1,6 @@
 import { IconDotsVertical, IconEdit } from '@tabler/icons-react';
 import { AlertDialog, Button, Dialog, DropdownMenu } from 'erxes-ui';
-import { Trash2 } from 'lucide-react';
+import {IconTrash} from '@tabler/icons-react';
 import { useState } from 'react';
 import { useFormContext, UseFormSetValue } from 'react-hook-form';
 import { NodeData } from '../../../types';
@@ -78,7 +78,7 @@ export const NodeDropdownActions = ({
           <AlertDialog>
             <AlertDialog.Trigger asChild>
               <Button variant="ghost" className="w-full justify-start">
-                <Trash2 className="h-4 w-4 text-red-500" />
+                <IconTrash className="h-4 w-4 text-red-500" />
                 Delete
               </Button>
             </AlertDialog.Trigger>

--- a/frontend/core-ui/src/modules/automations/utils/ErrorState.tsx
+++ b/frontend/core-ui/src/modules/automations/utils/ErrorState.tsx
@@ -1,6 +1,6 @@
 import { IconAlertCircle } from '@tabler/icons-react';
 import { Button, Collapsible } from 'erxes-ui';
-import { ChevronDown, ChevronUp, RefreshCw, X } from 'lucide-react';
+import { IconChevronDown, IconChevronUp, IconRefresh, IconX } from '@tabler/icons-react';
 import { useState } from 'react';
 
 interface ErrorStateProps {
@@ -36,7 +36,7 @@ export function ErrorState({
                 className="h-6 w-6 rounded-full -mt-1 -mr-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100"
                 onClick={onDismiss}
               >
-                <X className="h-4 w-4" />
+                <IconX className="h-4 w-4" />
                 <span className="sr-only">Dismiss</span>
               </Button>
             )}
@@ -67,9 +67,9 @@ export function ErrorState({
                   {isOpen ? 'Hide details' : 'Show details'}
                 </span>
                 {isOpen ? (
-                  <ChevronUp className="h-3 w-3 ml-1" />
+                  <IconChevronUp className="h-3 w-3 ml-1" />
                 ) : (
-                  <ChevronDown className="h-3 w-3 ml-1" />
+                  <IconChevronDown className="h-3 w-3 ml-1" />
                 )}
               </Button>
             </Collapsible.Trigger>
@@ -90,7 +90,7 @@ export function ErrorState({
             className="text-sm border-red-200 hover:bg-red-50 hover:text-red-700 hover:border-red-300"
             onClick={onRetry}
           >
-            <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+            <IconRefresh className="h-3.5 w-3.5 mr-1.5" />
             Try again
           </Button>
         </div>

--- a/frontend/core-ui/src/modules/settings/components/ChooseTheme.tsx
+++ b/frontend/core-ui/src/modules/settings/components/ChooseTheme.tsx
@@ -1,5 +1,3 @@
-// Dependencies: pnpm install lucide-react
-
 import { IconCheck, IconMinus } from '@tabler/icons-react';
 
 import { RadioGroup } from 'erxes-ui';

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "jsonwebtoken": "^9.0.2",
     "libphonenumber-js": "^1.11.20",
     "lodash": "^4.17.21",
-    "lucide-react": "^0.462.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.48",
     "mongoose": "^8.9.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,9 +287,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      lucide-react:
-        specifier: ^0.462.0
-        version: 0.462.0(react@18.3.1)
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -9461,11 +9458,6 @@ packages:
     resolution: {integrity: sha512-0S+JudK0AD9vyB0zbu1K0aQsy8k9Wq2l03bio6wxqF2FhK2TSp/y+22HfMyv40EURifgxoSwdU8eIcOv0a8gBA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
-
-  lucide-react@0.462.0:
-    resolution: {integrity: sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   luxon@3.6.1:
     resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
@@ -24309,10 +24301,6 @@ snapshots:
   lru-cache@7.18.3: {}
 
   lucide-react@0.362.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-
-  lucide-react@0.462.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
## Summary by Sourcery

Remove lucide-react dependency and migrate all icon usage to @tabler/icons-react across UI components

Enhancements:
- Replace lucide-react icon imports and component usages with @tabler/icons-react equivalents in core UI modules

Chores:
- Remove lucide-react from package.json and pnpm-lock.yaml
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `lucide-react` and replace its icons with `@tabler/icons-react` equivalents across the codebase.
> 
>   - **Dependencies**:
>     - Remove `lucide-react` from `package.json`.
>   - **Imports**:
>     - Replace `Search` with `IconSearch` in `AutomationBuilderSidebar.tsx`.
>     - Replace `Trash2` with `IconTrash` in `NodeActions.tsx`.
>     - Replace `ChevronDown`, `ChevronUp`, `RefreshCw`, `X` with `IconChevronDown`, `IconChevronUp`, `IconRefresh`, `IconX` in `ErrorState.tsx`.
>   - **Misc**:
>     - Remove comment about `lucide-react` dependency in `ChooseTheme.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 468bf2d5bce74147bac04b8903dfc18e4bbac28b. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->