### PR TITLE
facebook(fix) subdomain fix

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/controller.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/controller.ts
@@ -1,5 +1,5 @@
 import { generateModels, IModels } from '~/connectionResolvers';
-import { getSubdomain } from 'erxes-api-shared/utils';
+import { getSubdomain, isDev } from 'erxes-api-shared/utils';
 import { debugFacebook, debugError } from '@/integrations/facebook/debuggers';
 import { checkIsAdsOpenThread } from '@/integrations/facebook/utils';
 import { NextFunction, Response } from 'express';
@@ -72,7 +72,10 @@ export const facebookSubscription = async (req, res) => {
   }
 };
 export const facebookWebhook = async (req, res, next) => {
-  const subdomain = getSubdomain(req);
+  const subdomain = isDev ? 'localhost' : getSubdomain(req);
+
+  debugFacebook(`Received webhook request for subdomain: ${subdomain}`);
+
   const models = await generateModels(subdomain);
   const data = req.body;
   if (data.object !== 'page' && !checkIsAdsOpenThread(data?.entry)) {


### PR DESCRIPTION
## Summary by Sourcery

Ensure the Facebook webhook handler falls back to 'localhost' in development and logs the resolved subdomain for debugging

Bug Fixes:
- Use 'localhost' as the subdomain when running in development mode for the Facebook webhook

Enhancements:
- Add debug logging to output the Facebook webhook request's subdomain
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix subdomain handling in `facebookWebhook` by using `'localhost'` in development and adding debug logging.
> 
>   - **Behavior**:
>     - In `facebookWebhook`, `subdomain` is set to `'localhost'` if `isDev` is true, otherwise uses `getSubdomain(req)`.
>     - Adds debug log in `facebookWebhook` to log received webhook requests with subdomain.
>   - **Imports**:
>     - Adds `isDev` import from `erxes-api-shared/utils`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 873965087eb0e2e3f626d9ec48db6ca98ddb2d4b. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of subdomains for Facebook webhook requests in development environments.
- **Chores**
  - Added debug logging for subdomain information on incoming webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->