### PR TITLE
fix(facebook-inbox): rename handleFacebookInboxMessage to processFacebookInboxMessage

### DIFF
--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/controller/store.ts
@@ -8,7 +8,7 @@ import { INTEGRATION_KINDS } from '@/integrations/facebook/constants';
 import { IFacebookIntegrationDocument } from '@/integrations/facebook/@types/integrations';
 import { IFacebookCustomer } from '@/integrations/facebook/@types/customers';
 import { getFacebookUser } from '@/integrations/facebook/utils';
-import { receiveTrpcMessage } from '@/inbox/receiveMessage';
+import { receiveInboxMessage } from '@/inbox/receiveMessage';
 import { graphqlPubsub } from 'erxes-api-shared/utils';
 import { pConversationClientMessageInserted } from '@/inbox/graphql/resolvers/mutations/widget';
 import { sendTRPCMessage } from 'erxes-api-shared/utils';
@@ -73,7 +73,7 @@ export const getOrCreateCustomer = async (
     throw e; // Preserve stack trace
   }
 
-  // Save in core API (via receiveTrpcMessage)
+  // Save in core API (via receiveInboxMessage)
   try {
     const data = {
       action: 'get-create-update-customer',
@@ -86,7 +86,7 @@ export const getOrCreateCustomer = async (
       }),
     };
 
-    const apiCustomerResponse = await receiveTrpcMessage(subdomain, data);
+    const apiCustomerResponse = await receiveInboxMessage(subdomain, data);
 
     if (apiCustomerResponse.status === 'success') {
       customer.erxesApiId = apiCustomerResponse.data._id;
@@ -184,7 +184,7 @@ export const getOrCreateComment = async (
       }),
     };
 
-    const apiConversationResponse = await receiveTrpcMessage(subdomain, data);
+    const apiConversationResponse = await receiveInboxMessage(subdomain, data);
 
     if (apiConversationResponse.status === 'success') {
       conversation.erxesApiId = apiConversationResponse.data._id;

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/userMiddleware.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/middlewares/userMiddleware.ts
@@ -1,5 +1,5 @@
 import { getSubdomain } from 'erxes-api-shared/utils';
-import { receiveTrpcMessage } from '@/inbox/receiveMessage';
+import { receiveInboxMessage } from '@/inbox/receiveMessage';
 export let userIds: string[] = [];
 
 export const userMiddleware = async (req, _res, next) => {
@@ -11,7 +11,7 @@ export const userMiddleware = async (req, _res, next) => {
       action: 'getUserIds',
     };
 
-    const response = await receiveTrpcMessage(subdomain, data);
+    const response = await receiveInboxMessage(subdomain, data);
     if (response.status === 'success') {
       userIds = response.data.userIds;
     } else {


### PR DESCRIPTION
## Summary by Sourcery

Update Facebook integration to use the new receiveInboxMessage handler in place of the deprecated receiveTrpcMessage across controllers and middleware.

Enhancements:
- Import and use receiveInboxMessage instead of receiveTrpcMessage in Facebook store controller.
- Update user middleware to call receiveInboxMessage for fetching user IDs.
- Revise inline comments to reference receiveInboxMessage accordingly.