### PR TITLE
fix(tourism): update tour

### DIFF
--- a/backend/plugins/tourism_api/src/modules/bms/@types/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/@types/tour.ts
@@ -18,6 +18,7 @@ export interface ITour {
   groupSize: number;
   guides: IGuideItem[];
   status: string;
+  date_status: string;
   cost: number;
   branchId: string;
   tags: string[];
@@ -58,5 +59,5 @@ export interface TourFilterParams {
 export interface TourListResponse {
   list: ITourDocument[];
   totalCount: number;
-  pageInfo: IPageInfo
+  pageInfo: IPageInfo;
 }

--- a/backend/plugins/tourism_api/src/modules/bms/constants.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/constants.ts
@@ -8,6 +8,7 @@ export const TOUR_STATUS_TYPES = [
   { label: 'running', value: 'running' },
   { label: 'completed', value: 'completed' },
   { label: 'scheduled', value: 'scheduled' },
+  { label: 'unscheduled', value: 'unscheduled' },
   { label: 'cancelled', value: 'cancelled' },
 ];
 

--- a/backend/plugins/tourism_api/src/modules/bms/db/definitions/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/db/definitions/tour.ts
@@ -13,6 +13,7 @@ export const guideItemSchema = new Schema(
 );
 export const tourSchema = new Schema({
   _id: mongooseStringRandomId,
+
   createdAt: { type: Date, label: 'Created at' },
   modifiedAt: { type: Date, label: 'Modified at' },
   refNumber: { type: String, optional: true, label: 'refnumber' },
@@ -33,10 +34,17 @@ export const tourSchema = new Schema({
   status: {
     type: String,
     default: '',
-    enum: getEnum(TOUR_STATUS_TYPES),
     optional: true,
     label: 'status',
     esType: 'keyword',
+  },
+  date_status: {
+    type: String,
+    default: '',
+    optional: true,
+    label: 'date status',
+    esType: 'keyword',
+    selectOptions: getEnum(TOUR_STATUS_TYPES),
   },
   cost: { type: Number, optional: true, label: 'cost' },
   tagIds: { type: [String], optional: true, label: 'tagIds' },

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/resolvers/queries/tour.ts
@@ -38,6 +38,7 @@ const tourQueries = {
       endDate1,
       startDate2,
       endDate2,
+      date_status,
       ...params
     }: TourFilterParams,
     { models }: IContext,
@@ -60,6 +61,9 @@ const tourQueries = {
       selector.startDate = { $lte: innerDate };
       selector.endDate = { $gte: innerDate };
     }
+    if (date_status) {
+      selector.date_status = date_status;
+    }
 
     buildDateSelector(selector, 'startDate', startDate1, startDate2);
     buildDateSelector(selector, 'endDate', endDate1, endDate2);
@@ -79,6 +83,127 @@ const tourQueries = {
     { models }: IContext,
   ): Promise<ITourDocument | null> {
     return models.Tours.findById(_id);
+  },
+  async bmToursGroup(
+    _root,
+    {
+      categories,
+      status,
+      innerDate,
+      branchId,
+      tags,
+      startDate1,
+      endDate1,
+      startDate2,
+      endDate2,
+      groupCode,
+      date_status,
+      ...params
+    },
+    { models }: IContext,
+  ) {
+    const selector: any = {};
+
+    if (categories) {
+      selector.categories = { $in: categories };
+    }
+    if (status) {
+      selector.status = status;
+    }
+    if (branchId) {
+      selector.status = branchId;
+    }
+    if (tags) {
+      selector.tags = { $in: tags };
+    }
+    if (innerDate) {
+      const dateToCheck = innerDate;
+      selector.startDate = { $lte: dateToCheck };
+      selector.endDate = { $gte: dateToCheck };
+
+      // selector.$expr = {
+      //   $lte: [
+      //     dateToCheck,
+      //     {
+      //       $add: [
+      //         '$startDate',
+      //         { $multiply: ['$duration', 24 * 60 * 60 * 1000] },
+      //       ],
+      //     },
+      //   ],
+      // };
+    }
+
+    if (startDate2) {
+      if (!selector.startDate) selector.startDate = {};
+      selector.startDate['$lte'] = startDate2;
+    }
+    if (startDate1) {
+      if (!selector.startDate) selector.startDate = {};
+      selector.startDate['$gte'] = startDate1;
+    }
+
+    if (endDate2) {
+      if (!selector.endDate) selector.endDate = {};
+      selector.endDate['$lte'] = endDate2;
+    }
+    if (endDate1) {
+      if (!selector.endDate) selector.endDate = {};
+      selector.endDate['$gte'] = endDate1;
+    }
+    if (groupCode) {
+      selector.groupCode = groupCode;
+    }
+    if (date_status) {
+      selector.date_status = date_status;
+    }
+
+    // const list = await models.Tours.find({
+    //   ...selector,
+    //   groupCode: { $in: [null, ''] },
+    // })
+    //   .limit(perPage)
+    //   .skip(skip)
+    //   .sort({ [sortField]: sortDirection === -1 ? sortDirection : 1 });
+    const total = await models.Tours.find({
+      ...selector,
+      groupCode: { $nin: [null, ''] },
+    }).countDocuments();
+
+    const { list, totalCount, pageInfo } = await cursorPaginate({
+      model: models.Tours,
+      params,
+      query: { ...selector, groupCode: { $nin: [null, ''] } },
+    });
+
+    const group = await models.Tours.aggregate([
+      {
+        $match: {
+          ...selector,
+          groupCode: { $nin: [null, ''] }, // Exclude null and empty strings
+        },
+      },
+      {
+        $group: {
+          _id: '$groupCode', // group by category
+          items: { $push: '$$ROOT' }, // push full documents into an array
+        },
+      },
+    ]);
+    return {
+      list: [...group],
+      total,
+    };
+  },
+  async bmToursGroupDetail(_root, { groupCode, status }, { models }: IContext) {
+    const selector: any = {};
+
+    const list = await models.Tours.find({
+      groupCode: groupCode,
+      status: status,
+    });
+
+    return { _id: groupCode, items: list };
   },
 };
 

--- a/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
+++ b/backend/plugins/tourism_api/src/modules/bms/graphql/schemas/tour.ts
@@ -6,12 +6,19 @@ export const types = `
     guide: User
     type: String
   }
-
+  enum DATE_STATUS {
+    running
+    completed
+    scheduled
+    cancelled
+    unscheduled
+  }
   type Tour {
     _id: String!
     branchId: String
     name: String
     refNumber: String
+    groupCode: String
     content: String
     duration: Int
     location: [BMSLocation]
@@ -22,16 +29,21 @@ export const types = `
     endDate: Date
     groupSize: Int
     status: String
+    date_status: DATE_STATUS
     cost: Float
     orders: [BmsOrder]
     createdAt: Date
     modifiedAt: Date
     viewCount: Int
-    tags: [String]
+    advanceCheck: Boolean
+    advancePercent: Float
+    joinPercent: Float
+    tagIds: [String]
     info1: String
     info2: String
     info3: String
     info4: String
+    info5: String
     extra: JSON
     images: [String]
     imageThumbnail: String
@@ -47,7 +59,9 @@ export const types = `
     note: String
     numberOfPeople: Int
     type: String
-    additionalCustomers: String
+    additionalCustomers: [String]
+    isChild: Boolean
+    parent: String   
   }
 
   input BmsOrderInput {
@@ -59,7 +73,9 @@ export const types = `
     note: String
     numberOfPeople: Int
     type: String
-    additionalCustomers: String
+    additionalCustomers: [String]
+    isChild: Boolean
+    parent: String
   }
   input GuideItemInput {
     guideId: String
@@ -75,34 +91,50 @@ export const types = `
     pageInfo: PageInfo
     totalCount: Int
   }
+  type GroupTourItem {
+    items:[Tour]
+    _id: String
+  }
+  type GroupTour {
+    list:[GroupTourItem]
+    total: Int
+  }
 `;
 
 export const queries = `
-  bmsTours(branchId:String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String],startDate1:Date,startDate2:Date,endDate1:Date,endDate2:Date): TourListResponse
+  bmsTours(branchId:String, ${GQL_CURSOR_PARAM_DEFS}, status: String, innerDate: Date, tags: [String],startDate1:Date,startDate2:Date,endDate1:Date,endDate2:Date,  date_status: DATE_STATUS): TourListResponse
   bmsTourDetail(_id:String!,branchId: String): Tour
   bmsOrders( tourId:String, customerId:String ,branchId: String, ${GQL_CURSOR_PARAM_DEFS}):BmsOrderListResponse
+  bmToursGroup(branchId:String, , ${GQL_CURSOR_PARAM_DEFS} status: String, innerDate: Date,branchId: String, tags: [String],startDate1:Date,startDate2:Date,endDate1:Date,endDate2:Date,date_status: DATE_STATUS): GroupTour
+  bmToursGroupDetail(groupCode:String,status: String): GroupTourItem
 `;
 
 const params = `
   branchId: String,
   name: String,
+  groupCode: String,
   content: String,
   itineraryId:String,
   startDate: Date,
   endDate: Date,
   groupSize: Int,
   duration: Int,
+  advancePercent: Float,
+  joinPercent: Float,
+  advanceCheck: Boolean,
   status: String,
+  date_status: DATE_STATUS!
   cost: Float,
   location: [BMSLocationInput],
   guides:[GuideItemInput],
   refNumber: String,
-  tags:[String],
+  tagIds:[String],
   viewCount: Int,
   info1: String,
   info2: String,
   info3: String,
   info4: String,
+  info5: String,
   extra: JSON,
   images: [String],
   imageThumbnail: String


### PR DESCRIPTION
## Summary by Sourcery

Add date_status filtering and grouping capabilities for tours; extend tour model and GraphQL schema to include new status enum and additional fields; introduce bmToursGroup and bmToursGroupDetail queries

New Features:
- Add bmToursGroup and bmToursGroupDetail GraphQL queries to group tours by groupCode

Enhancements:
- Introduce DATE_STATUS enum and enable filtering tours by date_status in existing queries
- Extend Tour type and resolver inputs with new fields: groupCode, date_status, advanceCheck, advancePercent, joinPercent, tagIds, info5, additionalCustomers array, isChild, and parent
- Update database schema, TypeScript interfaces, and constants to support date_status field and add 'unscheduled' status option