### PR TITLE
move internal note to core

### DIFF
--- a/backend/core-api/src/apollo/resolvers/mutations.ts
+++ b/backend/core-api/src/apollo/resolvers/mutations.ts
@@ -1,9 +1,11 @@
 import { appMutations } from '@/apps/graphql/mutations';
 import { authMutations } from '@/auth/graphql/resolvers/mutations';
+import { automationMutations } from '@/automations/graphql/resolvers/mutations';
 import conformityMutations from '@/conformities/graphql/mutations';
 import { contactMutations } from '@/contacts/graphql/resolvers/mutations';
 import { documentMutations } from '@/documents/graphql/mutations';
 import { exchangeRateMutations } from '@/exchangeRates/graphql/resolvers/mutations';
+import { internalNoteMutations } from '@/internalNote/graphql/mutations';
 import { brandMutations } from '@/organization/brand/graphql/mutations';
 import { organizationConfigMutations } from '@/organization/settings/graphql/configs/mutations';
 import { favoriteMutations } from '@/organization/settings/graphql/favorites/mutations';
@@ -15,7 +17,6 @@ import { productMutations } from '@/products/graphql/resolvers/mutations';
 import { relationsMutations } from '@/relations/graphql/mutations';
 import { segmentMutations } from '@/segments/graphql/resolvers/mutations';
 import { tagMutations } from '@/tags/graphql/mutations';
-import { automationMutations } from '@/automations/graphql/resolvers/mutations';
 
 export const mutations = {
   ...contactMutations,
@@ -36,4 +37,5 @@ export const mutations = {
   ...usersGroupMutations,
   ...documentMutations,
   ...automationMutations,
+  ...internalNoteMutations,
 };

--- a/backend/core-api/src/apollo/resolvers/queries.ts
+++ b/backend/core-api/src/apollo/resolvers/queries.ts
@@ -1,9 +1,12 @@
 import { appQueries } from '@/apps/graphql/queries';
 import { authQueries } from '@/auth/graphql/resolvers/queries';
+import { automationQueries } from '@/automations/graphql/resolvers/queries';
 import { contactQueries } from '@/contacts/graphql/resolvers/queries';
 import { documentQueries } from '@/documents/graphql/queries';
 import { exchangeRateQueries } from '@/exchangeRates/graphql/resolvers';
 import { queries as formQueries } from '@/forms/graphql/resolvers';
+import { internalNoteQueries } from '@/internalNote/graphql/queries';
+import { logQueries } from '@/logs/graphql/resolvers/queries';
 import { brandQueries } from '@/organization/brand/graphql/queries';
 import { organizationConfigQueries } from '@/organization/settings/graphql/configs/queries';
 import { favoriteQueries } from '@/organization/settings/graphql/favorites/queries';
@@ -15,8 +18,6 @@ import { productQueries } from '@/products/graphql/resolvers/queries';
 import { relationsQueries } from '@/relations/graphql/queries';
 import { segmentQueries } from '@/segments/graphql/resolvers';
 import { tagQueries } from '@/tags/graphql/queries';
-import { automationQueries } from '@/automations/graphql/resolvers/queries';
-import { logQueries } from '@/logs/graphql/resolvers/queries';
 
 export const queries = {
   ...contactQueries,
@@ -38,4 +39,5 @@ export const queries = {
   ...documentQueries,
   ...automationQueries,
   ...logQueries,
+  ...internalNoteQueries,
 };

--- a/backend/core-api/src/apollo/resolvers/resolvers.ts
+++ b/backend/core-api/src/apollo/resolvers/resolvers.ts
@@ -1,11 +1,12 @@
+import automationsResolvers from '@/automations/graphql/resolvers/customResolver';
 import contactResolvers from '@/contacts/graphql/resolvers/customResolvers';
+import internalNoteResolvers from '@/internalNote/graphql/customResolvers';
+import logResolvers from '@/logs/graphql/resolvers/customResolvers';
+import brandResolvers from '@/organization/brand/graphql/customResolver/brand';
+import structureResolvers from '@/organization/structure/graphql/resolvers/customResolvers';
+import userResolvers from '@/organization/team-member/graphql/customResolver';
 import productResolvers from '@/products/graphql/resolvers/customResolvers';
 import segmentResolvers from '@/segments/graphql/resolvers/customResolvers';
-import structureResolvers from '@/organization/structure/graphql/resolvers/customResolvers';
-import logResolvers from '@/logs/graphql/resolvers/customResolvers';
-import automationsResolvers from '@/automations/graphql/resolvers/customResolver';
-import userResolvers from '@/organization/team-member/graphql/customResolver';
-import brandResolvers from '@/organization/brand/graphql/customResolver/brand';
 import tagResolvers from '@/tags/graphql/customResolvers';
 
 export const customResolvers = {
@@ -18,4 +19,5 @@ export const customResolvers = {
   ...userResolvers,
   ...brandResolvers,
   ...tagResolvers,
+  ...internalNoteResolvers,
 };

--- a/backend/core-api/src/apollo/schema/schema.ts
+++ b/backend/core-api/src/apollo/schema/schema.ts
@@ -141,6 +141,12 @@ import {
   types as LogsTypes,
 } from '@/logs/graphql/schema';
 
+import {
+  mutations as InternalNoteMutations,
+  queries as InternalNoteQueries,
+  types as InternalNoteTypes,
+} from '@/internalNote/graphql/schemas';
+
 export const types = `
     enum CacheControlScope {
       PUBLIC
@@ -179,6 +185,7 @@ export const types = `
     ${DocumentTypes}
     ${AutomationsTypes}
     ${LogsTypes}
+    ${InternalNoteTypes}
   `;
 
 export const queries = `
@@ -206,6 +213,7 @@ export const queries = `
     ${DocumentQueries}
     ${AutomationsQueries}
     ${LogsQueries}
+    ${InternalNoteQueries}
   `;
 
 export const mutations = `
@@ -232,6 +240,7 @@ export const mutations = `
     ${UsersGroupMutations}
     ${DocumentMutations}
     ${AutomationsMutations}
+    ${InternalNoteMutations}
   `;
 
 export default { types, queries, mutations };

--- a/backend/core-api/src/connectionResolvers.ts
+++ b/backend/core-api/src/connectionResolvers.ts
@@ -131,6 +131,17 @@ import {
 } from './modules/segments/db/models/Segments';
 
 import {
+  IInternalNoteModel,
+  loadInternalNoteClass,
+} from '@/internalNote/db/models/InternalNote';
+import { IInternalNoteDocument } from '@/internalNote/types';
+import { ILogModel, loadLogsClass } from '@/logs/db/models/Logs';
+import {
+  IAutomationDocument,
+  IAutomationExecutionDocument,
+} from 'erxes-api-shared/core-modules';
+
+import {
   IAutomationModel,
   loadClass as loadAutomationClass,
 } from './modules/automations/db/models/Automations';
@@ -138,11 +149,6 @@ import {
   IExecutionModel,
   loadClass as loadExecutionClass,
 } from './modules/automations/db/models/Executions';
-import {
-  IAutomationDocument,
-  IAutomationExecutionDocument,
-} from 'erxes-api-shared/core-modules';
-import { ILogModel, loadLogsClass } from './modules/logs/db/models/Logs';
 
 export interface IModels {
   Brands: IBrandModel;
@@ -154,6 +160,7 @@ export interface IModels {
   Permissions: IPermissionModel;
   UsersGroups: IUserGroupModel;
   Tags: ITagModel;
+  InternalNotes: IInternalNoteModel;
   Products: IProductModel;
   ProductCategories: IProductCategoryModel;
   ProductsConfigs: IProductsConfigModel;
@@ -237,6 +244,11 @@ export const loadClasses = (
   );
 
   models.Tags = db.model<ITagDocument, ITagModel>('tags', loadTagClass(models));
+
+  models.InternalNotes = db.model<IInternalNoteDocument, IInternalNoteModel>(
+    'internal_notes',
+    loadInternalNoteClass(models),
+  );
 
   models.Products = db.model<IProductDocument, IProductModel>(
     'products',

--- a/backend/core-api/src/modules/internalNote/db/definitions/internalNote.ts
+++ b/backend/core-api/src/modules/internalNote/db/definitions/internalNote.ts
@@ -1,0 +1,19 @@
+import { mongooseStringRandomId } from 'erxes-api-shared/utils';
+import { Schema } from 'mongoose';
+
+export const internalNoteSchema = new Schema(
+  {
+    _id: mongooseStringRandomId,
+    contentType: {
+      type: String,
+      label: 'Content type',
+      index: true,
+    },
+    contentTypeId: { type: String, label: 'Content item', index: true },
+    content: { type: String, label: 'Content' },
+    createdUserId: { type: String, label: 'Created by' },
+  },
+  {
+    timestamps: true,
+  },
+);

--- a/backend/core-api/src/modules/internalNote/db/models/InternalNote.ts
+++ b/backend/core-api/src/modules/internalNote/db/models/InternalNote.ts
@@ -1,0 +1,99 @@
+import { Model } from 'mongoose';
+import { IModels } from '~/connectionResolvers';
+import { internalNoteSchema } from '~/modules/internalNote/db/definitions/internalNote';
+import {
+  IInternalNote,
+  IInternalNoteDocument,
+} from '~/modules/internalNote/types';
+
+export interface IInternalNoteModel extends Model<IInternalNoteDocument> {
+  getInternalNote(_id: string): Promise<IInternalNoteDocument>;
+  createInternalNote(
+    { contentType, contentTypeId, ...fields }: IInternalNote,
+    user,
+  ): Promise<IInternalNoteDocument>;
+  updateInternalNote(
+    _id: string,
+    doc: IInternalNote,
+  ): Promise<IInternalNoteDocument>;
+  removeInternalNote(_id: string): void;
+  removeInternalNotes(
+    contentType: string,
+    contentTypeIds: string[],
+  ): Promise<{ n: number; ok: number }>;
+}
+
+export const loadInternalNoteClass = (models: IModels) => {
+  class InternalNote {
+    public static async getInternalNote(_id: string) {
+      const internalNote = await models.InternalNotes.findOne({ _id }).lean();
+
+      if (!internalNote) {
+        throw new Error('Internal note not found');
+      }
+
+      return internalNote;
+    }
+
+    /*
+     * Create new internalNote
+     */
+    public static async createInternalNote(
+      { contentType, contentTypeId, ...fields }: IInternalNote,
+      user,
+    ) {
+      const internalNote = await models.InternalNotes.create({
+        contentType,
+        contentTypeId,
+        createdUserId: user._id,
+        ...fields,
+      });
+
+      return internalNote;
+    }
+
+    /*
+     * Update internalNote
+     */
+    public static async updateInternalNote(_id: string, doc: IInternalNote) {
+      return models.InternalNotes.findOneAndUpdate(
+        { _id },
+        { $set: doc },
+        { new: true },
+      );
+    }
+
+    /*
+     * Remove internalNote
+     */
+    public static async removeInternalNote(_id: string) {
+      const internalNoteObj = await models.InternalNotes.findOneAndDelete({
+        _id,
+      });
+
+      if (!internalNoteObj) {
+        throw new Error(`InternalNote not found with id ${_id}`);
+      }
+
+      return internalNoteObj;
+    }
+
+    /**
+     * Remove internal notes
+     */
+    public static async removeInternalNotes(
+      contentType: string,
+      contentTypeIds: string[],
+    ) {
+      // Removing every internal notes of contentType
+      return models.InternalNotes.deleteMany({
+        contentType,
+        contentTypeId: { $in: contentTypeIds },
+      });
+    }
+  }
+
+  internalNoteSchema.loadClass(InternalNote);
+
+  return internalNoteSchema;
+};

--- a/backend/core-api/src/modules/internalNote/db/models/InternalNote.ts
+++ b/backend/core-api/src/modules/internalNote/db/models/InternalNote.ts
@@ -16,7 +16,7 @@ export interface IInternalNoteModel extends Model<IInternalNoteDocument> {
     _id: string,
     doc: IInternalNote,
   ): Promise<IInternalNoteDocument>;
-  removeInternalNote(_id: string): void;
+  removeInternalNote(_id: string): Promise<IInternalNoteDocument>;
   removeInternalNotes(
     contentType: string,
     contentTypeIds: string[],
@@ -42,14 +42,12 @@ export const loadInternalNoteClass = (models: IModels) => {
       { contentType, contentTypeId, ...fields }: IInternalNote,
       user,
     ) {
-      const internalNote = await models.InternalNotes.create({
+      return await models.InternalNotes.create({
         contentType,
         contentTypeId,
         createdUserId: user._id,
         ...fields,
       });
-
-      return internalNote;
     }
 
     /*

--- a/backend/core-api/src/modules/internalNote/graphql/customResolvers/index.ts
+++ b/backend/core-api/src/modules/internalNote/graphql/customResolvers/index.ts
@@ -1,0 +1,5 @@
+import InternalNote from './internalNote';
+
+export default {
+  InternalNote,
+};

--- a/backend/core-api/src/modules/internalNote/graphql/customResolvers/internalNote.ts
+++ b/backend/core-api/src/modules/internalNote/graphql/customResolvers/internalNote.ts
@@ -1,0 +1,16 @@
+import { IContext } from '~/connectionResolvers';
+import { IInternalNoteDocument } from '~/modules/internalNote/types';
+
+export default {
+  async createdUser(
+    note: IInternalNoteDocument,
+    _args: unknown,
+    { models }: IContext,
+  ) {
+    if (!note.createdUserId) {
+      return;
+    }
+
+    return await models.Users.findOne({ _id: note.createdUserId }).lean();
+  },
+};

--- a/backend/core-api/src/modules/internalNote/graphql/mutations.ts
+++ b/backend/core-api/src/modules/internalNote/graphql/mutations.ts
@@ -1,0 +1,117 @@
+import {
+  graphqlPubsub,
+  isEnabled,
+  sendTRPCMessage,
+} from 'erxes-api-shared/utils';
+import { IContext } from '~/connectionResolvers';
+import { IInternalNote } from '~/modules/internalNote/types';
+
+export const internalNoteMutations = {
+  /**
+   * Adds internalNote object and also adds an activity log
+   */
+  async internalNotesAdd(
+    _root: undefined,
+    args: IInternalNote,
+    { user, models }: IContext,
+  ) {
+    const { contentType, contentTypeId, mentionedUserIds = [] } = args;
+
+    const [pluginName, moduleName] = contentType.split(':');
+
+    const isServiceAvailable = await isEnabled(pluginName);
+    if (!isServiceAvailable) {
+      return null;
+    }
+
+    const notifDoc = {
+      title: `${moduleName.toUpperCase()} updated`,
+      createdUser: user,
+      action: `mentioned you in ${contentType}`,
+      receivers: mentionedUserIds,
+      content: '',
+      link: '',
+      notifType: '',
+      contentType: '',
+      contentTypeId: '',
+    };
+
+    const updatedNotifDoc = await sendTRPCMessage({
+      pluginName,
+      method: 'query',
+      module: moduleName,
+      action: 'generateInternalNoteNotif',
+      input: {
+        type: moduleName,
+        contentTypeId,
+        notifDoc,
+      },
+      defaultValue: {},
+    });
+
+    if (updatedNotifDoc.notifOfItems) {
+      const { item } = updatedNotifDoc;
+
+      const relatedReceivers = await sendTRPCMessage({
+        pluginName,
+        method: 'query',
+        module: moduleName,
+        action: 'notifiedUserIds',
+        input: {
+          item,
+        },
+        defaultValue: [],
+      });
+
+      updatedNotifDoc.action = `added note in ${contentType}`;
+
+      updatedNotifDoc.receivers = relatedReceivers.filter((id) => {
+        return [...mentionedUserIds, user._id].indexOf(id) < 0;
+      });
+
+      //   sendNotificationsMessage({
+      //     subdomain,
+      //     action: 'send',
+      //     data: updatedNotifDoc,
+      //   });
+
+      graphqlPubsub.publish('activityLogsChanged', {});
+    }
+
+    if (updatedNotifDoc.contentType) {
+      //   await sendNotificationsMessage({
+      //     subdomain,
+      //     action: 'send',
+      //     data: updatedNotifDoc,
+      //   });
+    }
+
+    return models.InternalNotes.createInternalNote(args, user);
+  },
+
+  /**
+   * Updates internalNote object
+   */
+  async internalNotesEdit(
+    _root,
+    { _id, ...doc }: IInternalNote & { _id: string },
+    { models }: IContext,
+  ) {
+    graphqlPubsub.publish('activityLogsChanged', {});
+
+    return models.InternalNotes.updateInternalNote(_id, doc);
+  },
+
+  /**
+   * Removes an internal note
+   */
+  async internalNotesRemove(
+    _root,
+    { _id }: { _id: string },
+    { models }: IContext,
+  ) {
+    graphqlPubsub.publish('activityLogsChanged', {});
+
+    return models.InternalNotes.removeInternalNote(_id);
+  },
+};

--- a/backend/core-api/src/modules/internalNote/graphql/queries.ts
+++ b/backend/core-api/src/modules/internalNote/graphql/queries.ts
@@ -1,0 +1,105 @@
+import { sendTRPCMessage } from 'erxes-api-shared/utils';
+import { IContext } from '~/connectionResolvers';
+import { IInternalNoteParams } from '~/modules/internalNote/types';
+
+export const internalNoteQueries = {
+  internalNoteDetail: async (
+    _parent: undefined,
+    { _id }: { _id: string },
+    { models }: IContext,
+  ) => {
+    return await models.InternalNotes.getInternalNote(_id);
+  },
+
+  /**
+   * InternalNotes list
+   */
+  async internalNotes(
+    _parent: undefined,
+    {
+      contentType,
+      contentTypeId,
+    }: { contentType: string; contentTypeId: string },
+    { models }: IContext,
+  ) {
+    const filter: { contentType: string; contentTypeId?: string } = {
+      contentType,
+    };
+
+    if (contentTypeId) {
+      filter.contentTypeId = contentTypeId;
+    }
+
+    return await models.InternalNotes.find(filter)
+      .sort({
+        createdAt: 1,
+      })
+      .lean();
+  },
+
+  async internalNotesByAction(
+    _parent: undefined,
+    { contentType, pipelineId, page = 1, perPage = 10 }: IInternalNoteParams,
+    { models }: IContext,
+  ) {
+    const [pluginName, moduleName] = contentType.split(':');
+
+    const contentIds = await sendTRPCMessage({
+      pluginName,
+      method: 'query',
+      module: moduleName,
+      action: 'contentIds',
+      input: {
+        pipelineId,
+      },
+      defaultValue: [],
+    });
+
+    let totalCount = 0;
+
+    const filter = { contentTypeId: { $in: contentIds } };
+
+    const list: any[] = [];
+
+    const internalNotes = await models.InternalNotes.find(filter)
+      .sort({
+        createdAt: -1,
+      })
+      .skip(perPage * (page - 1))
+      .limit(perPage)
+      .lean();
+
+    for (const note of internalNotes) {
+      list.push({
+        _id: note._id,
+        action: 'addNote',
+        contentType: note.contentType,
+        contentId: note.contentTypeId,
+        createdAt: note.createdAt,
+        createdBy: note.createdUserId,
+        content: note.content,
+      });
+    }
+
+    totalCount = await models.InternalNotes.countDocuments(filter);
+
+    return { list, totalCount };
+  },
+
+  async internalNotesAsLogs(
+    _parent: undefined,
+    { contentTypeId }: { contentTypeId: string },
+    { models }: IContext,
+  ) {
+    const notes = await models.InternalNotes.find({ contentTypeId })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    // convert to activityLog schema
+    return notes.map((n) => ({
+      ...n,
+      contentId: contentTypeId,
+      contentType: 'note',
+    }));
+  },
+};

--- a/backend/core-api/src/modules/internalNote/graphql/schemas.ts
+++ b/backend/core-api/src/modules/internalNote/graphql/schemas.ts
@@ -1,0 +1,44 @@
+const commonFields = `
+  _id: String!
+  contentType: String!
+  createdAt: Date
+`;
+
+export const types = `
+
+  type InternalNote {
+    ${commonFields}
+    contentTypeId: String
+    content: String
+    createdUserId: String
+
+    createdUser: User
+  }
+
+  type ModifiedNote {
+    ${commonFields}
+    createdBy: String
+    contentId: String
+    action: String
+    content: String
+    contentTypeDetail: JSON
+  }
+
+  type InternalNotesByAction {
+    list: [ModifiedNote]
+    totalCount: Int
+  }
+`;
+
+export const queries = `
+  internalNoteDetail(_id: String!): InternalNote
+  internalNotes(contentType: String!, contentTypeId: String): [InternalNote]
+  internalNotesByAction(contentType: String, pipelineId: String, page: Int, perPage: Int): InternalNotesByAction
+  internalNotesAsLogs(contentTypeId: String!): [JSON]
+`;
+
+export const mutations = `
+  internalNotesAdd(contentType: String!, contentTypeId: String, content: String, mentionedUserIds: [String]): InternalNote
+  internalNotesEdit(_id: String!, content: String, mentionedUserIds: [String]): InternalNote
+  internalNotesRemove(_id: String!): InternalNote
+`;

--- a/backend/core-api/src/modules/internalNote/types.ts
+++ b/backend/core-api/src/modules/internalNote/types.ts
@@ -1,0 +1,21 @@
+import { Document } from 'mongoose';
+
+export interface IInternalNote {
+  contentType: string;
+  contentTypeId: string;
+  content: string;
+  mentionedUserIds?: string[];
+}
+
+export interface IInternalNoteDocument extends IInternalNote, Document {
+  _id: string;
+  createdUserId: string;
+  createdAt: Date;
+}
+
+export interface IInternalNoteParams {
+  contentType: string;
+  pipelineId: string;
+  page: number;
+  perPage: number;
+}

--- a/backend/core-api/src/modules/products/graphql/resolvers/customResolvers/product.ts
+++ b/backend/core-api/src/modules/products/graphql/resolvers/customResolvers/product.ts
@@ -1,4 +1,4 @@
-// import { IProductDocument } from 'erxes-api-shared/core-types';
+import { IProductDocument } from 'erxes-api-shared/core-types';
 import { IContext } from '~/connectionResolvers';
 
 export default {
@@ -8,24 +8,26 @@ export default {
   ) => {
     return models.Products.findOne({ _id });
   },
-  // category: async (
-  //   product: IProductDocument,
-  //   _args: undefined,
-  //   { dataLoaders }: IContext,
-  // ) => {
-  //   return (
-  //     (product.categoryId &&
-  //       dataLoaders?.productCategory.load(product.categoryId)) ||
-  //     null
-  //   );
-  // },
-  // vendor: (
-  //   product: IProductDocument,
-  //   _args: undefined,
-  //   { dataLoaders }: IContext,
-  // ) => {
-  //   return (
-  //     (product.vendorId && dataLoaders?.company.load(product.vendorId)) || null
-  //   );
-  // },
+  category: async (
+    product: IProductDocument,
+    _args: undefined,
+    { models }: IContext,
+  ) => {
+    if (!product.categoryId) {
+      return null;
+    }
+
+    return models.ProductCategories.findOne({ _id: product.categoryId });
+  },
+  vendor: async (
+    product: IProductDocument,
+    _args: undefined,
+    { models }: IContext,
+  ) => {
+    if (!product.vendorId) {
+      return null;
+    }
+
+    return models.Companies.findOne({ _id: product.vendorId });
+  },
 };

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/pipelines.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/queries/pipelines.ts
@@ -42,7 +42,7 @@ export const pipelineQueries = {
       const userDetail = await sendTRPCMessage({
         pluginName: 'core',
         method: 'query',
-        module: 'user',
+        module: 'users',
         action: 'find',
         input: {
           _id: user._id,

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -1,0 +1,84 @@
+import { initTRPC } from '@trpc/server';
+import { ITRPCContext } from 'erxes-api-shared/utils';
+import { z } from 'zod';
+import { IModels } from '~/connectionResolvers';
+
+export type SalesTRPCContext = ITRPCContext<{ models: IModels }>;
+
+const t = initTRPC.context<SalesTRPCContext>().create();
+
+export const dealTrpcRouter = t.router({
+  deal: {
+    contentIds: t.procedure.input(z.any()).query(async ({ ctx, input }) => {
+      const { pipelineId } = input;
+      const { models } = ctx;
+
+      const stageIds = await models.Stages.find({ pipelineId }).distinct('_id');
+
+      return models.Deals.find({ stageId: { $in: stageIds } }).distinct('_id');
+    }),
+    generateInternalNoteNotif: t.procedure
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
+        const { contentTypeId, notifDoc, type } = input;
+        const { models } = ctx;
+
+        const card = await models.Deals.getDeal(contentTypeId);
+        const stage = await models.Stages.getStage(card.stageId);
+        const pipeline = await models.Pipelines.getPipeline(stage.pipelineId);
+
+        notifDoc.notifType = `${type}Delete`;
+        notifDoc.content = `"${card.name}"`;
+        notifDoc.link = `/${type}/board?id=${pipeline.boardId}&pipelineId=${pipeline._id}&itemId=${card._id}`;
+        notifDoc.contentTypeId = card._id;
+        notifDoc.contentType = `${type}`;
+        notifDoc.item = card;
+
+        // sendNotificationOfItems on and deal
+        notifDoc.notifOfItems = true;
+
+        return notifDoc;
+      }),
+    notifiedUserIds: t.procedure
+      .input(z.any())
+      .query(async ({ ctx, input }) => {
+        const { item } = input;
+        const { models } = ctx;
+
+        let userIds: string[] = [];
+
+        userIds = userIds.concat(item.assignedUserIds || []);
+
+        userIds = userIds.concat(item.watchedUserIds || []);
+
+        const stage = await models.Stages.getStage(item.stageId);
+        const pipeline = await models.Pipelines.getPipeline(stage.pipelineId);
+
+        userIds = userIds.concat(pipeline.watchedUserIds || []);
+
+        return userIds;
+      }),
+    tag: t.procedure.input(z.any()).mutation(async ({ ctx, input }) => {
+      const { action, _ids, tagIds, targetIds } = input;
+      const { models } = ctx;
+
+      let response = {};
+
+      if (action === 'count') {
+        response = await models.Deals.countDocuments({ tagIds: { $in: _ids } });
+      }
+
+      if (action === 'tagObject') {
+        await models.Deals.updateMany(
+          { _id: { $in: targetIds } },
+          { $set: { tagIds } },
+          { multi: true },
+        );
+
+        response = await models.Deals.find({ _id: { $in: targetIds } }).lean();
+      }
+
+      return response;
+    }),
+  },
+});

--- a/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
+++ b/backend/plugins/sales_api/src/modules/sales/trpc/deal.ts
@@ -72,7 +72,6 @@ export const dealTrpcRouter = t.router({
         await models.Deals.updateMany(
           { _id: { $in: targetIds } },
           { $set: { tagIds } },
-          { multi: true },
         );
 
         response = await models.Deals.find({ _id: { $in: targetIds } }).lean();

--- a/backend/plugins/sales_api/src/trpc/init-trpc.ts
+++ b/backend/plugins/sales_api/src/trpc/init-trpc.ts
@@ -1,5 +1,5 @@
+import { dealTrpcRouter } from '@/sales/trpc/deal';
 import { initTRPC } from '@trpc/server';
-
 import { ITRPCContext } from 'erxes-api-shared/utils';
 import { IModels } from '~/connectionResolvers';
 
@@ -7,12 +7,6 @@ export type SalesTRPCContext = ITRPCContext<{ models: IModels }>;
 
 const t = initTRPC.context<SalesTRPCContext>().create();
 
-export const appRouter = t.router({
-  sample: {
-    hello: t.procedure.query(() => {
-      return 'Hello Sample';
-    }),
-  },
-});
+export const appRouter = t.mergeRouters(dealTrpcRouter);
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary by Sourcery

Add a new internalNote module to core-api supporting creation, editing, removal, and querying of internal notes with notification flows; refactor product and tag GraphQL resolvers for consistent model access and plugin routing; integrate internalNote into the Apollo schema and resolvers; and enhance the sales_api plugin with a consolidated TRPC router for deal operations.

New Features:
- Add internalNote feature in core-api with Mongoose model, GraphQL schema (types, queries, mutations), custom resolvers, and notification-triggering logic
- Introduce dealTrpcRouter in sales_api plugin to handle deal-related contentIds, internal note notifications, and tagging via TRPC

Enhancements:
- Refactor product resolvers to fetch categories and vendors directly via models instead of data loaders
- Refactor tagMutations to use pluginName/moduleName naming and delegate non-core actions through sendTRPCMessage
- Integrate internalNote module into Apollo root resolvers and schema and register InternalNotes in connectionResolvers models
- Replace sample TRPC appRouter with merged dealTrpcRouter and fix TRPC pipelines query module name
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `internalNote` module to core API with GraphQL support and enhance sales API with TRPC router for deals.
> 
>   - **New Features**:
>     - Add `internalNote` module with Mongoose model, GraphQL schema, and custom resolvers in `internalNote/db/models/InternalNote.ts`, `internalNote/graphql/mutations.ts`, and `internalNote/graphql/queries.ts`.
>     - Integrate `internalNote` into Apollo schema in `schema.ts` and resolvers in `resolvers.ts`.
>     - Add notification logic for internal notes in `internalNote/graphql/mutations.ts`.
>   - **Enhancements**:
>     - Refactor product resolvers in `products/graphql/resolvers/customResolvers/product.ts` to fetch categories and vendors directly via models.
>     - Refactor `tagMutations` in `tags/graphql/mutations.ts` to use `pluginName/moduleName` naming and delegate non-core actions through `sendTRPCMessage`.
>     - Add `dealTrpcRouter` in `sales_api/src/modules/sales/trpc/deal.ts` for deal-related operations and integrate it in `init-trpc.ts`.
>   - **Misc**:
>     - Fix TRPC pipelines query module name in `sales_api/src/modules/sales/graphql/resolvers/queries/pipelines.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 9985a1b0ef159fe57f9508b8adcf193460b86b26. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced internal notes functionality, allowing users to add, edit, and remove internal notes linked to various content types.
  * Added the ability to view, query, and paginate internal notes, including logs and detailed note information.
  * Enhanced notification support for internal note activities, including user mentions and activity log updates.
  * Added a new deal-related API for fetching content IDs, generating notifications, managing notified users, and tagging deals.

* **Improvements**
  * Improved product-related data by enabling direct lookup of product categories and vendors.
  * Extended tagging functionality to support plugins and modules beyond the core system.
  * Refined sales pipeline queries for accurate user data retrieval by correcting module naming.
  * Modularized sales API router for better scalability and maintenance.

* **Bug Fixes**
  * Corrected user module reference in sales pipeline queries to ensure accurate user data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->