### PR TITLE
chore: cursor paginate on pipelines & add fields groups trpc

### DIFF
--- a/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
+++ b/backend/core-api/src/modules/forms/trpc/fieldsGroups.ts
@@ -1,0 +1,25 @@
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+import { CoreTRPCContext } from '~/init-trpc';
+
+const t = initTRPC.context<CoreTRPCContext>().create();
+
+export const fieldsGroupsTrpcRouter = t.router({
+  fieldsGroups: t.router({
+    find: t.procedure
+      .input(z.object({ query: z.any() }))
+      .query(async ({ ctx, input }) => {
+        const { query } = input;
+        const { models } = ctx;
+        return await models.FieldsGroups.find(query).lean();
+      }),
+    updateGroup: t.procedure
+      .input(z.object({ groupId: z.string(), fieldGroup: z.any() }))
+      .mutation(async ({ ctx, input }) => {
+        const { groupId, fieldGroup } = input;
+        const { models } = ctx;
+        return await models.FieldsGroups.updateGroup(groupId, fieldGroup);
+      }),
+  }),
+});

--- a/backend/core-api/src/modules/forms/trpc/index.ts
+++ b/backend/core-api/src/modules/forms/trpc/index.ts
@@ -1,6 +1,10 @@
 import { initTRPC } from '@trpc/server';
 import { fieldsTrpcRouter } from './fields';
+import { fieldsGroupsTrpcRouter } from './fieldsGroups';
 
 const t = initTRPC.create();
 
-export const formsTrpcRouter = t.mergeRouters(fieldsTrpcRouter);
+export const formsTrpcRouter = t.mergeRouters(
+  fieldsTrpcRouter,
+  fieldsGroupsTrpcRouter,
+);

--- a/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/boards.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/resolvers/mutations/boards.ts
@@ -50,8 +50,8 @@ export const boardMutations = {
 
       await sendTRPCMessage({
         pluginName: 'core',
-        method: 'query',
-        module: 'fieldsGroups', // ??
+        method: 'mutation',
+        module: 'fieldsGroups',
         action: 'updateGroup',
         input: { groupId: fieldGroup._id, fieldGroup },
       });

--- a/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
+++ b/backend/plugins/sales_api/src/modules/sales/graphql/schemas/pipeline.ts
@@ -1,3 +1,5 @@
+import { GQL_CURSOR_PARAM_DEFS } from 'erxes-api-shared/utils';
+
 export const types = `
 
   type SalesPipeline @key(fields: "_id") {
@@ -39,6 +41,14 @@ export const types = `
     order: Int
     createdAt: Date
     type: String
+
+    cursor: String
+  }
+
+  type SalesPipelinesListResponse {
+    list: [SalesPipeline],
+    pageInfo: PageInfo
+    totalCount: Int,
   }
 
   input SalesOrderItem {
@@ -47,8 +57,15 @@ export const types = `
   }
 `;
 
+const queryParams = `
+  boardId: String,
+  isAll: Boolean
+
+  ${GQL_CURSOR_PARAM_DEFS}
+`;
+
 export const queries = `
-  salesPipelines(boardId: String, isAll: Boolean): [SalesPipeline]
+  salesPipelines(${queryParams}): SalesPipelinesListResponse
   salesPipelineDetail(_id: String!): SalesPipeline
   salesPipelineAssignedUsers(_id: String!): [User]
   salesPipelineStateCount(boardId: String): JSON


### PR DESCRIPTION
## Summary by Sourcery

Add cursor-based pagination to the salesPipelines GraphQL query and introduce a new fieldsGroups TRPC router while fixing the TRPC invocation method for field group updates

New Features:
- Add cursor pagination support to the salesPipelines query, returning paginated list, totalCount, and pageInfo
- Introduce fieldsGroups TRPC router with find and updateGroup procedures and merge it into the formsTrpcRouter

Bug Fixes:
- Correct the TRPC message method for updating field groups from 'query' to 'mutation'

Enhancements:
- Update the SalesPipeline GraphQL schema to include cursor field and define SalesPipelinesListResponse type
- Refactor the salesPipelines resolver to use the shared cursorPaginate utility with ICursorPaginateParams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cursor-based pagination to the sales pipelines query, including new pagination info and total count in responses.
  * Introduced new endpoints for finding and updating field groups.

* **Improvements**
  * Enhanced the sales pipelines GraphQL schema to include a cursor field and a new response type for paginated results.
  * Updated mutation operations for field groups to support more robust interaction.

* **API Changes**
  * Modified the sales pipelines query parameters and return structure to support advanced pagination.
  * Updated input and output formats for field group-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->