### PR TITLE
fix(inbox) inbox filter debug

### DIFF
--- a/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
+++ b/backend/plugins/frontline_api/src/modules/inbox/graphql/resolvers/queries/conversations.ts
@@ -45,7 +45,8 @@ export const conversationQueries = {
     });
 
     await qb.buildAllQueries();
-
+    const query = await qb.mainQuery();
+    console.log(query, 'query');
     const { list, totalCount, pageInfo } =
       await cursorPaginate<IConversationDocument>({
         model: models.Conversations,
@@ -54,7 +55,7 @@ export const conversationQueries = {
           orderBy: { createdAt: -1 },
           limit: params.limit || 20,
         },
-        query: qb.mainQuery(),
+        query: [],
       });
 
     return { list, totalCount, pageInfo };


### PR DESCRIPTION
## Summary by Sourcery

Instrument the inbox conversation resolver to log the constructed query and temporarily override the pagination filter for debugging purposes.

Bug Fixes:
- Temporarily bypass the conversation pagination filter by replacing `qb.mainQuery()` with an empty array

Enhancements:
- Log the generated inbox query for debugging filter issues