### PR TITLE
refactor(facebook): remove Redis caching and fetch configs directly from DB

### DIFF
--- a/backend/plugins/frontline_api/.env.sample
+++ b/backend/plugins/frontline_api/.env.sample
@@ -23,4 +23,4 @@ TIMEZONE=8
 CALL_CRON_API_USER=
 CALL_CRON_API_PASSWORD=
 
-ENDPOINT_URL=http://localhost:4444
+ENDPOINT_URL=https://enterprise.erxes.io

--- a/backend/plugins/frontline_api/.env.sample
+++ b/backend/plugins/frontline_api/.env.sample
@@ -23,4 +23,4 @@ TIMEZONE=8
 CALL_CRON_API_USER=
 CALL_CRON_API_PASSWORD=
 
-ENDPOINT_URL=https://enterprise.erxes.io
+ENDPOINT_URL=http://localhost:4444

--- a/backend/plugins/frontline_api/src/modules/integrations/facebook/commonUtils.ts
+++ b/backend/plugins/frontline_api/src/modules/integrations/facebook/commonUtils.ts
@@ -26,25 +26,21 @@ export const generateAttachmentUrl = (subdomain: string, urlOrName: string) => {
 };
 
 export const getConfigs = async (models: IModels) => {
-  const configsCache = await redis.get(CACHE_NAME);
-
-  if (configsCache && configsCache !== '{}') {
-    return JSON.parse(configsCache);
-  }
-
-  const configsMap = {};
+  const configsMap: Record<string, string> = {};
   const configs = await models.FacebookConfigs.find({});
 
   for (const config of configs) {
     configsMap[config.code] = config.value;
   }
 
-  await redis.set(CACHE_NAME, JSON.stringify(configsMap));
-
   return configsMap;
 };
 
-export const getConfig = async (models: IModels, code, defaultValue?) => {
+export const getConfig = async (
+  models: IModels,
+  code: string,
+  defaultValue?: string,
+) => {
   const VERSION = getEnv({ name: 'VERSION' });
 
   if (VERSION && VERSION === 'saas') {
@@ -65,7 +61,6 @@ export const getConfig = async (models: IModels, code, defaultValue?) => {
 
   return configs[code];
 };
-
 export const resetConfigsCache = async () => {
   await redis.set(CACHE_NAME, '');
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor Facebook integration to eliminate Redis-based caching and fetch configurations directly from the database

Enhancements:
- Remove Redis caching for Facebook configurations and always load directly from the database
- Simplify getConfig function signature with explicit type annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Facebook integration settings now reflect changes immediately, reducing instances of outdated or inconsistent configuration values.
  * Improved reliability of configuration retrieval across environments.

* **Refactor**
  * Streamlined configuration handling for the Facebook integration.
  * Improved type safety and parameter validation for configuration access methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->