### PR TITLE
Operation final

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/cycle/components/CyclesColumns.tsx
+++ b/frontend/plugins/operation_ui/src/modules/cycle/components/CyclesColumns.tsx
@@ -53,7 +53,7 @@ export const cyclesColumns: ColumnDef<ICycle>[] = [
       const handleUpdate = () => {
         if (value !== name) {
           updateCycle({
-            variables: { input: { _id: cell.row.original._id, name: value } },
+            variables: { _id: cell.row.original._id, name: value },
           });
         }
       };
@@ -90,12 +90,12 @@ export const cyclesColumns: ColumnDef<ICycle>[] = [
               value={value || ''}
               onChange={(e) => setValue(e.target.value)}
               autoFocus
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  handleUpdate();
-                }
-              }}
+              // onKeyDown={(e) => {
+              //   if (e.key === 'Enter') {
+              //     e.preventDefault();
+              //     handleUpdate();
+              //   }
+              // }}
             />
           </RecordTableInlineCell.Content>
         </PopoverScoped>
@@ -194,7 +194,7 @@ export const cyclesColumns: ColumnDef<ICycle>[] = [
       <RecordTable.InlineHead label="Status" icon={IconProgressCheck} />
     ),
     cell: ({ cell }) => {
-      const { isActive, isCompleted} = cell.row.original;
+      const { isActive, isCompleted } = cell.row.original;
       return (
         <RecordTableInlineCell>
           <CycleStatusDisplay isActive={isActive} isCompleted={isCompleted} />

--- a/frontend/plugins/operation_ui/src/modules/project/components/select/SelectStatus.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/components/select/SelectStatus.tsx
@@ -304,7 +304,7 @@ export const SelectStatusInlineCell = ({
     >
       <PopoverScoped
         open={open}
-        onOpenChange={setOpen}
+      onOpenChange={setOpen}
         scope={finalScope}
         closeOnEnter
       >

--- a/frontend/plugins/operation_ui/src/modules/task/components/StatusInline.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/StatusInline.tsx
@@ -11,16 +11,19 @@ import React from 'react';
 import { TeamStatusTypes } from '@/team/constants';
 
 export const StatusInlineIcon = React.forwardRef<
-  Icon,
-  React.ComponentProps<Icon> & { type: number; color?: string }
+  SVGSVGElement,
+  React.ComponentProps<'svg'> & { type: number; color?: string }
 >(({ type, color, style, className, ...props }) => {
-  const TeamStatusIcon = {
+  const TeamStatusIconMap: Record<number, React.ComponentType<any>> = {
     [TeamStatusTypes.Backlog]: IconCircleDashed,
     [TeamStatusTypes.Unstarted]: IconCircle,
     [TeamStatusTypes.Started]: IconCircleDot,
     [TeamStatusTypes.Completed]: IconCircleCheck,
     [TeamStatusTypes.Cancelled]: IconCircleX,
-  }[type] as React.ComponentType<React.ComponentProps<Icon>>;
+  };
+
+  const numericType = typeof type === 'string' ? parseInt(type, 10) : type;
+  const TeamStatusIcon = TeamStatusIconMap[numericType];
 
   if (!TeamStatusIcon) {
     return null;
@@ -34,3 +37,5 @@ export const StatusInlineIcon = React.forwardRef<
     />
   );
 });
+
+StatusInlineIcon.displayName = 'StatusInlineIcon';

--- a/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
@@ -153,7 +153,7 @@ export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
                 <Form.Control>
                   <Input
                     {...field}
-                    className="shadow-none focus-visible:shadow-none h-8 text-xl"
+                    className="shadow-none focus-visible:shadow-none h-8 text-xl p-0"
                     placeholder="Task Name"
                   />
                 </Form.Control>

--- a/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/add-task/AddTaskForm.tsx
@@ -75,7 +75,7 @@ export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
   });
   useEffect(() => {
     form.setFocus('name');
-  });
+  }, []);
 
   useEffect(() => {
     if (teams && teams.length > 0 && !form.getValues('teamId') && !teamId) {
@@ -288,7 +288,7 @@ export const AddTaskForm = ({ onClose }: { onClose: () => void }) => {
             <BlockEditor
               editor={editor}
               onChange={handleDescriptionChange}
-              className="min-h-full"
+              className="read-only min-h-full"
             />
           </div>
         </Sheet.Content>

--- a/frontend/plugins/operation_ui/src/modules/task/components/select/SelectAssigneeTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/select/SelectAssigneeTask.tsx
@@ -235,6 +235,7 @@ export const SelectAssigneeTaskFormItem = ({
       value={value}
       onValueChange={(value) => {
         onValueChange(value as string);
+        setOpen(false);
       }}
       mode="single"
     >

--- a/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
@@ -1,4 +1,4 @@
-import { Button, Select, TextOverflowTooltip, Form } from 'erxes-ui';
+import { Button, Select, Form } from 'erxes-ui';
 import { useGetActiveCycles } from '@/cycle/hooks/useGetActiveCycles';
 import { IconCalendarRepeat, IconBan } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -25,7 +25,7 @@ export const SelectCycle = ({
   return (
     <Select
       value={selectedValue}
-      onValueChange={(value) => {
+      onValueChange={(value: string) => {
         setSelectedValue(value);
         onChange(value === 'no-cycle' ? undefined : value);
       }}
@@ -47,7 +47,13 @@ export const SelectCycle = ({
             value={selectedValue || ''}
             className="font-medium"
           >
-            <TextOverflowTooltip value={selectedCycle.name} />
+            <span className="flex gap-2 items-center">
+              <span className="font-medium">{selectedCycle.name}</span>
+              <span className="text-xs text-muted-foreground">
+                {new Date(selectedCycle.startDate).toLocaleDateString()} -{' '}
+                {new Date(selectedCycle.endDate).toLocaleDateString()}
+              </span>
+            </span>
           </Select.Item>
         ) : (
           <Select.Item value="no-cycle" key="no-cycle">
@@ -77,7 +83,13 @@ export const SelectCycle = ({
                   value={cycle._id}
                   className="font-medium"
                 >
-                  <TextOverflowTooltip value={cycle.name} />
+                  <span className="flex gap-2 items-center">
+                    <span className="font-medium">{cycle.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(cycle.startDate).toLocaleDateString()} -{' '}
+                      {new Date(cycle.endDate).toLocaleDateString()}
+                    </span>
+                  </span>
                 </Select.Item>
               ))}
           </>

--- a/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
@@ -19,12 +19,12 @@ export const SelectCycle = ({
   const selectedCycle = activeCycles?.find(
     (cycle) => cycle._id === selectedValue,
   );
+
   return (
     <Select
       value={selectedValue}
       onValueChange={(value) => {
         setSelectedValue(value);
-        console.log(value, 'inside');
         onChange(value === 'no-cycle' ? undefined : value);
       }}
     >
@@ -56,27 +56,41 @@ export const SelectCycle = ({
           </Select.Item>
         )}
         <Select.Separator />
-        {selectedValue !== 'no-cycle' && (
-          <Select.Item value="no-cycle" key="no-cycle">
-            <span className="flex items-center gap-2 font-medium">
-              <IconBan className="size-4" />
-              No cycle
-            </span>
-          </Select.Item>
-        )}
-        {activeCycles &&
-          activeCycles
-            .filter((cycle) => cycle._id !== selectedValue)
-            .map((cycle) => (
-              <Select.Item
-                key={cycle._id}
-                value={cycle._id}
-                className="font-medium"
-              >
-                <TextOverflowTooltip value={cycle.name} />
+
+        {activeCycles && activeCycles.length > 0 ? (
+          <>
+            {selectedValue !== 'no-cycle' && (
+              <Select.Item value="no-cycle" key="no-cycle">
+                <span className="flex items-center gap-2 font-medium">
+                  <IconBan className="size-4" />
+                  No cycle
+                </span>
               </Select.Item>
-            ))}
+            )}
+            {activeCycles
+              .filter((cycle) => cycle._id !== selectedValue)
+              .map((cycle) => (
+                <Select.Item
+                  key={cycle._id}
+                  value={cycle._id}
+                  className="font-medium"
+                >
+                  <TextOverflowTooltip value={cycle.name} />
+                </Select.Item>
+              ))}
+          </>
+        ) : (
+          <SelectCycleEmpty />
+        )}
       </Select.Content>
     </Select>
+  );
+};
+
+const SelectCycleEmpty = () => {
+  return (
+    <div className="flex items-center gap-2 font-medium text-muted-foreground h-16 justify-center ">
+      No cycle on the selected team
+    </div>
   );
 };

--- a/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/select/SelectCycle.tsx
@@ -2,7 +2,7 @@ import { Button, Select, TextOverflowTooltip, Form } from 'erxes-ui';
 import { useGetActiveCycles } from '@/cycle/hooks/useGetActiveCycles';
 import { IconCalendarRepeat, IconBan } from '@tabler/icons-react';
 import { useState } from 'react';
-
+import { useGetTeam } from '@/team/hooks/useGetTeam';
 export const SelectCycle = ({
   teamId,
   value,
@@ -12,6 +12,7 @@ export const SelectCycle = ({
   value: string | undefined;
   onChange: (value: string | undefined) => void;
 }) => {
+  const { team } = useGetTeam({ variables: { _id: teamId }, skip: !teamId });
   const { activeCycles } = useGetActiveCycles(teamId);
   const [selectedValue, setSelectedValue] = useState<string | undefined>(
     value || 'no-cycle',
@@ -20,6 +21,7 @@ export const SelectCycle = ({
     (cycle) => cycle._id === selectedValue,
   );
 
+  if (!team?.cycleEnabled) return null;
   return (
     <Select
       value={selectedValue}

--- a/frontend/plugins/operation_ui/src/modules/task/components/select/SelectStatusTask.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/select/SelectStatusTask.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   cn,
   Combobox,
@@ -12,6 +12,7 @@ import { useUpdateTask } from '@/task/hooks/useUpdateTask';
 import { useGetStatusByTeam } from '@/task/hooks/useGetStatusByTeam';
 import { DEFAULT_TEAM_STATUSES } from '@/team/constants';
 import { StatusInlineIcon } from '@/task/components/StatusInline';
+import { TeamStatusTypes } from '@/team/constants';
 import {
   SelectOperationContent,
   SelectTriggerOperation,
@@ -45,11 +46,13 @@ export const SelectStatusProvider = ({
   onValueChange,
   teamId,
   children,
+  variant,
 }: {
   value: string;
   onValueChange: (status: string) => void;
   children: React.ReactNode;
   teamId?: string;
+  variant?: `${SelectTriggerVariant}`;
 }) => {
   const handleValueChange = (status: string) => {
     if (!status) return;
@@ -59,6 +62,15 @@ export const SelectStatusProvider = ({
     variables: { teamId },
     skip: !teamId,
   });
+  const fallBackStatus = statuses?.find(
+    (status) => status.type === TeamStatusTypes.Backlog,
+  )?.value;
+  useEffect(() => {
+    if (variant === SelectTriggerVariant.FORM && fallBackStatus) {
+      onValueChange(fallBackStatus);
+    }
+  }, [variant, fallBackStatus, onValueChange]);
+
   return (
     <SelectStatusContext.Provider
       value={{
@@ -253,6 +265,7 @@ export const SelectStatusTaskFormItem = ({
       value={value}
       onValueChange={onValueChange}
       teamId={teamId}
+      variant="form"
     >
       <PopoverScoped open={open} onOpenChange={setOpen} scope={scope}>
         <SelectTriggerOperation variant="form">

--- a/frontend/plugins/operation_ui/src/modules/team/components/SelectTeam.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/SelectTeam.tsx
@@ -236,9 +236,15 @@ const SelectTeamFormItem = ({
   onValueChange: (value: string | string[]) => void;
   mode?: 'single' | 'multiple';
 }) => {
+  const [open, setOpen] = useState(false);
   return (
-    <SelectTeamProvider value={value} onValueChange={onValueChange} mode={mode}>
-      <PopoverScoped>
+    <SelectTeamProvider
+      value={value}
+      onValueChange={onValueChange}
+      mode={mode}
+      setOpen={setOpen}
+    >
+      <PopoverScoped open={open} onOpenChange={setOpen}>
         <SelectTriggerOperation variant="form">
           <SelectTeamValue />
         </SelectTriggerOperation>

--- a/frontend/plugins/operation_ui/src/modules/team/components/team-list/CreateTeamForm.tsx
+++ b/frontend/plugins/operation_ui/src/modules/team/components/team-list/CreateTeamForm.tsx
@@ -11,36 +11,40 @@ export const CreateTeamForm = ({
 }) => {
   return (
     <div className="flex flex-col gap-3">
-      <Form.Field
-        control={form.control}
-        name="name"
-        render={({ field }) => (
-          <Form.Item>
-            <Form.Label>Team name</Form.Label>
-            <Form.Description className="sr-only">Team Name</Form.Description>
-            <Form.Control>
-              <Input {...field} />
-            </Form.Control>
-            <Form.Message />
-          </Form.Item>
-        )}
-      />
-
-      <Form.Field
-        control={form.control}
-        name="icon"
-        render={({ field }) => (
-          <Form.Item>
-            <Form.Label>Icon</Form.Label>
-            <Form.Description className="sr-only">Icon</Form.Description>
-            <Form.Control>
-              <IconPicker onValueChange={field.onChange} value={field.value} />
-            </Form.Control>
-            <Form.Message />
-          </Form.Item>
-        )}
-      />
-
+      <div className="w-full flex gap-2">
+        <Form.Field
+          control={form.control}
+          name="icon"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Icon</Form.Label>
+              <Form.Description className="sr-only">Icon</Form.Description>
+              <Form.Control>
+                <IconPicker
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  className="w-min"
+                />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <Form.Item className="flex-auto">
+              <Form.Label>Team name</Form.Label>
+              <Form.Description className="sr-only">Team Name</Form.Description>
+              <Form.Control>
+                <Input {...field} />
+              </Form.Control>
+              <Form.Message />
+            </Form.Item>
+          )}
+        />
+      </div>
       <Form.Field
         control={form.control}
         name="description"

--- a/frontend/plugins/operation_ui/src/pages/TeamDetailPage.tsx
+++ b/frontend/plugins/operation_ui/src/pages/TeamDetailPage.tsx
@@ -18,7 +18,7 @@ export const TeamDetailPage = () => {
                 <Button
                   variant="ghost"
                   className="text-foreground font-semibold"
-                  onClick={() => navigate(-1)}
+                  onClick={() => navigate('/settings/operation/team')}
                 >
                   <IconArrowLeft size={16} className="stroke-foreground" />
                   Teams


### PR DESCRIPTION
## Summary by Sourcery

Improve various UI components across the operation plugin by enhancing dropdown displays, form layouts, popover controls, status icon handling, and navigation behavior while fixing a useEffect bug.

New Features:
- Hide cycle selector when team cycles are disabled and show an empty state message.

Bug Fixes:
- Add a dependency array to the focus-setting useEffect in AddTaskForm to prevent infinite re-renders.

Enhancements:
- Display cycle names with date ranges in the cycle dropdown and consolidate empty state into a dedicated component.
- Refactor CreateTeamForm to align icon picker and team name input in a horizontal row with adjusted sizing.
- Update StatusInlineIcon to support SVG refs, handle string-type inputs for mapping, and assign a displayName.
- Introduce controlled popover open state in SelectTeam and automatically close the assignee popover after selection.
- Automatically select the backlog status for form variants in the status selector.
- Add read-only styling to BlockEditor and remove padding from the task name input.
- Change the team detail page back button to navigate to the explicit '/settings/operation/team' route.
- Simplify updateCycle mutation arguments and remove unused key event handlers.