### PR TITLE
feat(facebook): disable already used pages in selection

### DIFF
--- a/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookGetPages.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/facebook/components/FacebookGetPages.tsx
@@ -60,6 +60,7 @@ export const FacebookGetPages = () => {
             <Command.List>
               {facebookGetPages.map((page) => (
                 <Command.Item
+                  disabled={page.isUsed}
                   key={page.id}
                   value={page.name}
                   onSelect={() =>


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Mark already used Facebook pages as disabled in the page selection list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Facebook Pages selection now disables pages that are already connected/used, preventing accidental re-selection.
  * Disabled pages are visibly indicated and cannot be selected, clarifying availability at a glance.
  * Improves guidance during page linking by allowing selection only from eligible pages, reducing errors and streamlining setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->