### PR TITLE
refactor(frontline): update routing and module structure

### DIFF
--- a/frontend/plugins/frontline_ui/module-federation.config.ts
+++ b/frontend/plugins/frontline_ui/module-federation.config.ts
@@ -16,9 +16,7 @@ const config: ModuleFederationConfig = {
   name: 'frontline_ui',
   exposes: {
     './config': './src/config.tsx',
-    './inbox': './src/modules/inbox/Main.tsx',
-    './ticket': './src/modules/ticket/Main.tsx',
-    './frontline': './src/modules/integrations/Main.tsx',
+    './frontline': './src/modules/Main.tsx',
     './inboxSettings': './src/modules/inbox/Settings.tsx',
     './ticketSettings': './src/modules/ticket/Settings.tsx',
     './automationsWidget':

--- a/frontend/plugins/frontline_ui/src/config.tsx
+++ b/frontend/plugins/frontline_ui/src/config.tsx
@@ -38,6 +38,7 @@ export const CONFIG: IUIConfig = {
       hasSettings: true,
       hasRelationWidget: true,
       hasFloatingWidget: true,
+      settingsOnly: true,
     },
     {
       name: 'ticket',
@@ -45,6 +46,7 @@ export const CONFIG: IUIConfig = {
       path: 'ticket',
       hasSettings: true,
       hasRelationWidget: true,
+      settingsOnly: true,
     },
     {
       name: 'frontline',

--- a/frontend/plugins/frontline_ui/src/modules/FrontlineActions.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/FrontlineActions.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 export const FrontlineActions = () => {
   const location = useLocation();
 
-  if (!location.pathname.startsWith('/inbox')) {
+  if (!location.pathname.startsWith('/frontline/inbox')) {
     return null;
   }
 

--- a/frontend/plugins/frontline_ui/src/modules/FrontlineNavigation.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/FrontlineNavigation.tsx
@@ -5,11 +5,15 @@ import { NavigationMenuLinkItem } from 'erxes-ui';
 export const FrontlineNavigation = () => {
   return (
     <>
-      <NavigationMenuLinkItem name="Inbox" icon={IconMail} path="inbox" />
+      <NavigationMenuLinkItem
+        name="Inbox"
+        icon={IconMail}
+        path="frontline/inbox"
+      />
       <NavigationMenuLinkItem
         name="Ticket"
         icon={IconMessageReply}
-        path="ticket"
+        path="frontline/ticket"
       />
       <IntegrationNavigation />
     </>

--- a/frontend/plugins/frontline_ui/src/modules/FrontlineSubGroups.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/FrontlineSubGroups.tsx
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router-dom';
 export const FrontlineSubGroups = () => {
   const location = useLocation();
 
-  if (!location.pathname.startsWith('/inbox')) {
+  if (!location.pathname.startsWith('/frontline/inbox')) {
     return null;
   }
 

--- a/frontend/plugins/frontline_ui/src/modules/Main.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/Main.tsx
@@ -11,11 +11,24 @@ const CallDetailPage = lazy(() =>
     default: module.CallDetailPage,
   })),
 );
+const Inbox = lazy(() =>
+  import('~/pages/InboxIndexPage').then((module) => ({
+    default: module.default,
+  })),
+);
+
+const Ticket = lazy(() =>
+  import('~/pages/TicketIndexPage').then((module) => ({
+    default: module.default,
+  })),
+);
 
 const IntegrationsMain = () => {
   return (
     <Suspense fallback={<div />}>
       <Routes>
+        <Route path="/inbox" element={<Inbox />} />
+        <Route path="/ticket" element={<Ticket />} />
         <Route path="/calls" element={<CallIndexPage />} />
         <Route path="/calls/:id" element={<CallDetailPage />} />
       </Routes>

--- a/frontend/plugins/frontline_ui/src/modules/inbox/components/InboxActions.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/components/InboxActions.tsx
@@ -21,7 +21,7 @@ export const InboxActions = () => {
         )}
         asChild
       >
-        <Link to="/inbox">
+        <Link to="/frontline/inbox">
           <IconRefresh className="text-accent-foreground" />
           Reset filters
         </Link>

--- a/frontend/plugins/frontline_ui/src/modules/inbox/types/InboxPath.ts
+++ b/frontend/plugins/frontline_ui/src/modules/inbox/types/InboxPath.ts
@@ -1,4 +1,4 @@
 export enum InboxPath {
-  MainPage = '/inbox',
+  MainPage = '/frontline/inbox',
   IntegrationSettingsPage = '/settings/inbox/integrations/:integrationId',
 }

--- a/frontend/plugins/frontline_ui/src/modules/settings/constants/settingsRoutes.ts
+++ b/frontend/plugins/frontline_ui/src/modules/settings/constants/settingsRoutes.ts
@@ -2,5 +2,4 @@ export const SETTINGS_ROUTES = {
   '/settings/inbox/integrations': 'Integrations',
   '/settings/inbox/integrations-config': 'Integrations config',
   '/settings/inbox/channels': 'Channels',
-  '/settings/inbox/responses': 'Response templates',
 };

--- a/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/AutomationHistoryName.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/automations/modules/facebook/components/AutomationHistoryName.tsx
@@ -16,7 +16,10 @@ export const AutomationHistoryName = ({
       </Button>
       {`\u00A0/\u00A0`}
       <Button asChild variant="link">
-        <Link target="_blank" to={`/inbox/index?_id=${target?.conversationId}`}>
+        <Link
+          target="_blank"
+          to={`/frontline/inbox/index?_id=${target?.conversationId}`}
+        >
           {'See Conversation'}
           <IconExternalLink />
         </Link>

--- a/frontend/plugins/frontline_ui/src/widgets/notifications/my-inbox/components/NotificationConversationDetail.tsx
+++ b/frontend/plugins/frontline_ui/src/widgets/notifications/my-inbox/components/NotificationConversationDetail.tsx
@@ -35,7 +35,7 @@ const NotificationActionsSlot = () => {
 
     return createPortal(
       <Button variant="outline" asChild>
-        <Link to={`/inbox?conversationId=${conversationId}`}>
+        <Link to={`/frontline/inbox?conversationId=${conversationId}`}>
           Go to Conversation
           <IconExternalLink />
         </Link>


### PR DESCRIPTION
- Consolidated module exports by creating Main.tsx for routing.
- Updated paths in FrontlineActions, FrontlineNavigation, and InboxActions to include 'frontline' prefix.
- Added 'settingsOnly' property to config for inbox and ticket modules.
- Removed unused settings route for inbox responses.
- Adjusted InboxPath enum to reflect new routing structure.

## Summary by Sourcery

Refactor the frontline plugin by consolidating module entry points into a single Main.tsx, updating routing to use a 'frontline' prefix, and streamlining configuration and exports.

Enhancements:
- Unify module exports under a single Main.tsx and adjust module federation config accordingly
- Prefix inbox and ticket routes, navigation links, and internal path checks with 'frontline' and lazy-load their pages
- Add a 'settingsOnly' property to inbox and ticket widget configurations
- Remove the deprecated inbox responses settings route and update related path enums