### PR TITLE
refactor(settings): simplify SettingsSidebar component structure

### DIFF
--- a/frontend/core-ui/src/modules/settings/components/SettingsSidebar.tsx
+++ b/frontend/core-ui/src/modules/settings/components/SettingsSidebar.tsx
@@ -55,25 +55,23 @@ export function SettingsSidebar() {
         </SettingsNavigationGroup>
         <SettingsNavigationGroup name="Workspace">
           {SETTINGS_PATH_DATA.nav.map((item) => (
-            <Sidebar.MenuItem key={item.name}>
-              <NavigationMenuLinkItem
-                pathPrefix={AppPath.Settings}
-                path={item.path}
-                name={item.name}
-              />
-            </Sidebar.MenuItem>
+            <NavigationMenuLinkItem
+              pathPrefix={AppPath.Settings}
+              path={item.path}
+              name={item.name}
+              key={item.name}
+            />
           ))}
         </SettingsNavigationGroup>
 
         <SettingsNavigationGroup name="Core modules">
           {CORE_MODULES.filter((item) => item.hasSettings).map((item) => (
-            <Sidebar.MenuItem key={item.name}>
-              <NavigationMenuLinkItem
-                pathPrefix={AppPath.Settings}
-                path={item.path}
-                name={item.name}
-              />
-            </Sidebar.MenuItem>
+            <NavigationMenuLinkItem
+              key={item.name}
+              pathPrefix={AppPath.Settings}
+              path={item.path}
+              name={item.name}
+            />
           ))}
         </SettingsNavigationGroup>
 
@@ -84,13 +82,12 @@ export function SettingsSidebar() {
               name={pluginName.charAt(0).toUpperCase() + pluginName.slice(1)}
             >
               {modules.map((item) => (
-                <Sidebar.MenuItem key={item.name}>
-                  <NavigationMenuLinkItem
-                    pathPrefix={AppPath.Settings}
-                    path={item.path}
-                    name={item.name}
-                  />
-                </Sidebar.MenuItem>
+                <NavigationMenuLinkItem
+                  key={item.name}
+                  pathPrefix={AppPath.Settings}
+                  path={item.path}
+                  name={item.name}
+                />
               ))}
             </SettingsNavigationGroup>
           ),

--- a/frontend/libs/erxes-ui/src/components/switch.tsx
+++ b/frontend/libs/erxes-ui/src/components/switch.tsx
@@ -8,7 +8,7 @@ export const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full border-transparent transition-colors focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-accent shadow-inner p-1',
+      'peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full border-transparent transition-colors focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-not-allowed disabled:opacity-50 aria-[checked=true]:bg-primary aria-[checked=false]:bg-accent shadow-inner p-1',
       className,
     )}
     {...props}

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallSipActions.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/components/CallSipActions.tsx
@@ -34,7 +34,7 @@ export const TurnOffButton = () => {
     isConnected ? unregisterSip() : registerSip();
     setCallInfo((prev) => ({
       ...prev,
-      isUnregistered: isConnected ? false : true,
+      isUnregistered: isConnected,
     }));
   };
 

--- a/frontend/plugins/frontline_ui/src/modules/integrations/call/components/SipContainer.tsx
+++ b/frontend/plugins/frontline_ui/src/modules/integrations/call/components/SipContainer.tsx
@@ -51,7 +51,6 @@ export const SipContainer = ({ children }: { children: React.ReactNode }) => {
     user: operator?.gsUsername,
     password: operator?.gsPassword,
     port: parseInt(port?.toString() || '8089', 10),
-    autoRegister: true,
     iceServers: [
       {
         urls: `turn:${callConfigs.TURN_SERVER_URL}`,


### PR DESCRIPTION
- Removed unnecessary Sidebar.MenuItem wrappers around NavigationMenuLinkItem for cleaner JSX.
- Updated CallSipActions to directly set isUnregistered based on isConnected state.
- Removed autoRegister property from SipContainer configuration for improved clarity.

## Summary by Sourcery

Simplify SettingsSidebar structure by removing wrapper components, update Switch styling to use aria selectors, clean up SIP call registration logic and container configuration

Bug Fixes:
- Fix isUnregistered flag toggling in CallSipActions to align with isConnected state

Enhancements:
- Remove Sidebar.MenuItem wrappers around NavigationMenuLinkItem in SettingsSidebar for cleaner JSX
- Update Switch component classes to use aria-[checked] selectors instead of data-state attributes
- Remove autoRegister property from SipContainer configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call status handling in telephony integrations, ensuring accurate registration state when disconnecting.
* **Refactor**
  * Streamlined Settings sidebar navigation rendering with no visual changes.
  * Updated switch component styling to use ARIA state for more reliable, accessible state indication.
* **Chores**
  * Adjusted SIP registration behavior to rely on provider defaults, reducing unintended auto-registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->