### PR TITLE
chore: teamIds to objectId for aggregation

### DIFF
--- a/backend/plugins/operation_api/src/modules/team/graphql/resolvers/queries/team.ts
+++ b/backend/plugins/operation_api/src/modules/team/graphql/resolvers/queries/team.ts
@@ -1,5 +1,6 @@
 import { ITeamFilter } from '@/team/@types/team';
 import { getTeamEstimateChoises } from '@/team/utils';
+import { Types } from 'mongoose';
 import { IContext } from '~/connectionResolvers';
 
 export const teamQueries = {
@@ -55,7 +56,7 @@ export const teamQueries = {
     const filter: any = {};
 
     if (teamIds && teamIds?.length) {
-      filter.teamId = { $in: teamIds };
+      filter.teamId = { $in: teamIds.map((id) => new Types.ObjectId(id)) };
 
       return models.TeamMember.aggregate([
         { $match: filter },


### PR DESCRIPTION
## Summary by Sourcery

Convert string team IDs to Mongoose ObjectId in the team member aggregation filter to ensure correct query matching.

Enhancements:
- Change aggregation filter to map incoming teamIds to Types.ObjectId instances

Chores:
- Import Types from mongoose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and stability of team member results when filtering by specific teams.
  * Users selecting one or more teams in filters should now see consistent, complete member lists, resolving cases of missing or inconsistent results.
  * No changes to UI or workflows; behavior is more reliable across environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->