### PR TITLE
chore: replace empty string with null when un set cycleId & get full …

### DIFF
--- a/backend/plugins/operation_api/src/modules/cycle/utils.ts
+++ b/backend/plugins/operation_api/src/modules/cycle/utils.ts
@@ -241,7 +241,7 @@ export const getCycleProgressChart = async (
   chartData.chartData = fillMissingDays(
     chartDataAggregation,
     cycle.startDate,
-    differenceInCalendarDays(cycle.endDate, cycle.startDate),
+    differenceInCalendarDays(cycle.endDate, cycle.startDate) + 1,
   );
 
   return chartData;

--- a/backend/plugins/operation_api/src/modules/task/@types/task.ts
+++ b/backend/plugins/operation_api/src/modules/task/@types/task.ts
@@ -14,7 +14,7 @@ export interface ITask {
   tagIds?: string[];
   assigneeId?: string;
   createdBy?: string;
-  cycleId?: string;
+  cycleId?: string | null;
   projectId?: string;
   estimatePoint?: number;
   userId?: string;

--- a/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCycle.tsx
+++ b/frontend/plugins/operation_ui/src/modules/task/components/task-selects/SelectCycle.tsx
@@ -194,7 +194,7 @@ const SelectCycleRoot = ({
         updateTask({
           variables: {
             _id: taskId,
-            cycleId: value,
+            cycleId: value || null,
           },
         });
         setOpen(false);


### PR DESCRIPTION
…difference day in cycle

## Summary by Sourcery

Adjust cycle duration calculation and normalize cycleId unset values to null across backend and frontend

Enhancements:
- Include end date in cycle duration by adding 1 day to the calendar difference calculation
- Allow cycleId to be null in the ITask interface
- Convert empty cycleId values to null when updating tasks in the SelectCycle component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cycle progress chart now includes the final day of the cycle, fixing missing last-day data and improving accuracy of progress metrics.
  * Selecting “No cycle” on a task now properly clears its cycle, ensuring consistent behavior across the UI and API and preventing empty/invalid values from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->