### PR TITLE
Add Creator activity in Task and Project

### DIFF
--- a/backend/plugins/operation_api/src/modules/project/@types/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/@types/project.ts
@@ -13,6 +13,7 @@ export interface IProject {
   status: number;
   targetDate?: Date;
   leadId?: string;
+  createdBy?: string;
 }
 
 export interface IProjectFilter extends ICursorPaginateParams, IListParams {

--- a/backend/plugins/operation_api/src/modules/project/db/definitions/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/db/definitions/project.ts
@@ -11,7 +11,7 @@ export const projectSchema = new Schema(
     startDate: { type: Date, label: 'Start Date', default: null },
     targetDate: { type: Date, label: 'Target Date', default: null },
     leadId: { type: String, label: 'Lead ID', default: null },
-    createdBy: { type: String, label: 'Created By' },
+    createdBy: { type: String, label: 'Created By', default: null },
   },
   {
     timestamps: true,

--- a/backend/plugins/operation_api/src/modules/project/db/definitions/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/db/definitions/project.ts
@@ -11,6 +11,7 @@ export const projectSchema = new Schema(
     startDate: { type: Date, label: 'Start Date', default: null },
     targetDate: { type: Date, label: 'Target Date', default: null },
     leadId: { type: String, label: 'Lead ID', default: null },
+    createdBy: { type: String, label: 'Created By' },
   },
   {
     timestamps: true,

--- a/backend/plugins/operation_api/src/modules/project/graphql/resolvers/mutations/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/graphql/resolvers/mutations/project.ts
@@ -17,7 +17,7 @@ export const projectMutations = {
       description,
       leadId,
     },
-    { models }: IContext,
+    { models, user }: IContext,
   ) => {
     const createdProject = await models.Project.createProject({
       name,
@@ -28,6 +28,7 @@ export const projectMutations = {
       status,
       description,
       leadId,
+      createdBy: user._id,
     });
     graphqlPubsub.publish(`operationProjectChanged:${createdProject._id}`, {
       operationProjectChanged: {

--- a/backend/plugins/operation_api/src/modules/project/graphql/schema/project.ts
+++ b/backend/plugins/operation_api/src/modules/project/graphql/schema/project.ts
@@ -12,6 +12,7 @@ type Project {
     leadId: String
     startDate: Date
     targetDate: Date
+    createdBy: String
     createdAt: Date
     updatedAt: Date
 }

--- a/frontend/plugins/operation_ui/src/modules/activity/components/ActivityItemWrapper.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/ActivityItemWrapper.tsx
@@ -1,0 +1,32 @@
+import { MembersInline } from 'ui-modules';
+import { IActivity } from '@/activity/types';
+import {
+  ActivityIcon,
+  ActivityItem as ActivityItemContent,
+} from './ActivityItem';
+import { ActivityTimelineItem } from './ActivityTimelineItem';
+
+interface ActivityItemWrapperProps {
+  activity: IActivity;
+}
+
+export const ActivityItemWrapper = ({ activity }: ActivityItemWrapperProps) => {
+  const memberIds = activity.createdBy ? [activity.createdBy] : [];
+
+  return (
+    <ActivityTimelineItem
+      avatar={<ActivityIcon activity={activity} />}
+      createdAt={activity.createdAt?.toLocaleString()}
+      id={activity._id}
+    >
+      {activity.createdBy === 'system' ? (
+        <div className="text-accent-foreground">System</div>
+      ) : (
+        <MembersInline.Provider memberIds={memberIds}>
+          <MembersInline.Title />
+        </MembersInline.Provider>
+      )}
+      <ActivityItemContent activity={activity} />
+    </ActivityTimelineItem>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/activity/components/ActivityItemWrapper.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/ActivityItemWrapper.tsx
@@ -3,9 +3,8 @@ import { IActivity } from '@/activity/types';
 import {
   ActivityIcon,
   ActivityItem as ActivityItemContent,
-} from './ActivityItem';
-import { ActivityTimelineItem } from './ActivityTimelineItem';
-
+} from '@/activity/components/ActivityItem';
+import { ActivityTimelineItem } from '@/activity/components/ActivityTimelineItem';
 interface ActivityItemWrapperProps {
   activity: IActivity;
 }

--- a/frontend/plugins/operation_ui/src/modules/activity/components/ActivityList.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/ActivityList.tsx
@@ -1,13 +1,12 @@
 import { useActivities } from '@/activity/hooks/useActivities';
-import { ActivityIcon, ActivityItem } from '@/activity/components/ActivityItem';
-import { MembersInline } from 'ui-modules';
-import { RelativeDateDisplay } from 'erxes-ui';
 import { ITask } from '@/task/types';
 import { IProject } from '@/project/types';
 import { ActivityListProvider } from '@/activity/context/ActivityListContext';
 import { ACTIVITY_MODULES } from '@/activity/constants';
 import { NoteInputReadOnly } from '@/activity/components/NoteInputReadOnly';
 import { NoteInput } from '@/activity/components/NoteInput';
+import { CreatorInfo } from '@/activity/components/CreatorInfo';
+import { ActivityItemWrapper } from '@/activity/components/ActivityItemWrapper';
 
 export const ActivityList = ({
   contentId,
@@ -26,41 +25,11 @@ export const ActivityList = ({
     <div className="flex flex-col mb-12 gap-4">
       <ActivityListProvider contentDetail={contentDetail}>
         <div className="ml-2.5 relative before:absolute before:left-0 before:top-1 before:bottom-1 before:w-px before:bg-muted before:-translate-x-1/2  flex flex-col gap-6">
+          <CreatorInfo contentDetail={contentDetail} />
           {activities?.map((activity) =>
             activity.module === ACTIVITY_MODULES.TEAM ? null : (
               <div className="flex flex-col gap-2" key={activity._id}>
-                <div className="inline-flex gap-1">
-                  <div className="size-5 -ml-2.5 mt-0.5 shadow-xs rounded-full bg-background relative flex items-center justify-center">
-                    <ActivityIcon activity={activity} />
-                  </div>
-                  <div className="inline-flex gap-1 text-sm leading-6 flex-wrap">
-                    <div className="ml-1">
-                      {activity.createdBy && activity.createdBy === 'system' ? (
-                        <div className="text-accent-foreground">System</div>
-                      ) : (
-                        <MembersInline.Provider
-                          memberIds={
-                            activity.createdBy ? [activity.createdBy] : []
-                          }
-                        >
-                          <MembersInline.Title />
-                        </MembersInline.Provider>
-                      )}
-                    </div>
-                    <ActivityItem activity={activity} />
-                    <RelativeDateDisplay
-                      value={activity.createdAt?.toLocaleString()}
-                      key={activity._id}
-                      asChild
-                    >
-                      <div className="text-accent-foreground ml-2 cursor-default">
-                        <RelativeDateDisplay.Value
-                          value={activity.createdAt?.toLocaleString()}
-                        />
-                      </div>
-                    </RelativeDateDisplay>
-                  </div>
-                </div>
+                <ActivityItemWrapper activity={activity} />
                 {activity.module === ACTIVITY_MODULES.NOTE && (
                   <NoteInputReadOnly
                     key={activity._id}

--- a/frontend/plugins/operation_ui/src/modules/activity/components/ActivityTimelineItem.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/ActivityTimelineItem.tsx
@@ -1,0 +1,34 @@
+import { RelativeDateDisplay } from 'erxes-ui';
+import { ReactNode } from 'react';
+
+interface ActivityTimelineItemProps {
+  avatar: ReactNode;
+  children: ReactNode;
+  createdAt?: string;
+  id?: string;
+}
+
+export const ActivityTimelineItem = ({
+  avatar,
+  children,
+  createdAt,
+  id,
+}: ActivityTimelineItemProps) => {
+  return (
+    <div className="inline-flex gap-1">
+      <div className="size-5 -ml-2.5 mt-0.5 shadow-xs rounded-full bg-background relative flex items-center justify-center">
+        {avatar}
+      </div>
+      <div className="inline-flex gap-1 text-sm leading-6 flex-wrap ml-1">
+        {children}
+        {createdAt && (
+          <RelativeDateDisplay value={createdAt} key={id} asChild>
+            <div className="text-accent-foreground ml-2 cursor-default">
+              <RelativeDateDisplay.Value value={createdAt} />
+            </div>
+          </RelativeDateDisplay>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/activity/components/CreatorInfo.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/CreatorInfo.tsx
@@ -1,0 +1,41 @@
+import { MembersInline } from 'ui-modules';
+import { ITask } from '@/task/types';
+import { IProject } from '@/project/types';
+import { ActivityTimelineItem } from './ActivityTimelineItem';
+import { IconUser } from '@tabler/icons-react';
+
+interface CreatorInfoProps {
+  contentDetail: ITask | IProject;
+}
+
+export const CreatorInfo = ({ contentDetail }: CreatorInfoProps) => {
+  const memberIds = contentDetail.createdBy ? [contentDetail.createdBy] : [];
+  const hasCreator = Boolean(contentDetail.createdBy);
+  
+  return (
+    <ActivityTimelineItem
+      avatar={
+        hasCreator ? (
+          <MembersInline.Provider memberIds={memberIds}>
+            <MembersInline.Avatar />
+          </MembersInline.Provider>
+        ) : (
+          <div className="size-5 rounded-full bg-muted flex items-center justify-center">
+            <IconUser className="size-3 text-muted-foreground" />
+          </div>
+        )
+      }
+      createdAt={contentDetail.createdAt?.toLocaleString()}
+      id={contentDetail._id}
+    >
+      Created by{' '}
+      {hasCreator ? (
+        <MembersInline.Provider memberIds={memberIds}>
+          <MembersInline.Title />
+        </MembersInline.Provider>
+      ) : (
+        <span className="text-muted-foreground">Unknown</span>
+      )}
+    </ActivityTimelineItem>
+  );
+};

--- a/frontend/plugins/operation_ui/src/modules/activity/components/CreatorInfo.tsx
+++ b/frontend/plugins/operation_ui/src/modules/activity/components/CreatorInfo.tsx
@@ -1,7 +1,7 @@
 import { MembersInline } from 'ui-modules';
 import { ITask } from '@/task/types';
 import { IProject } from '@/project/types';
-import { ActivityTimelineItem } from './ActivityTimelineItem';
+import { ActivityTimelineItem } from '@/activity/components/ActivityTimelineItem';
 import { IconUser } from '@tabler/icons-react';
 
 interface CreatorInfoProps {

--- a/frontend/plugins/operation_ui/src/modules/project/graphql/queries/getProject.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/graphql/queries/getProject.tsx
@@ -13,6 +13,7 @@ export const GET_PROJECT = gql`
       leadId
       startDate
       targetDate
+      createdBy
       createdAt
       updatedAt
     }

--- a/frontend/plugins/operation_ui/src/modules/project/graphql/queries/getProjects.tsx
+++ b/frontend/plugins/operation_ui/src/modules/project/graphql/queries/getProjects.tsx
@@ -18,6 +18,7 @@ export const GET_PROJECTS = gql`
         leadId
         startDate
         targetDate
+        createdBy
         createdAt
         updatedAt
       } 

--- a/frontend/plugins/operation_ui/src/modules/project/types/index.ts
+++ b/frontend/plugins/operation_ui/src/modules/project/types/index.ts
@@ -7,7 +7,7 @@ export interface IProject {
   icon: string;
   tagIds: string[];
   createdAt: string;
-  createdBy: string;
+  createdBy?: string;
   priority: number;
   status: number;
   targetDate: Date;

--- a/frontend/plugins/operation_ui/src/modules/project/types/index.ts
+++ b/frontend/plugins/operation_ui/src/modules/project/types/index.ts
@@ -7,6 +7,7 @@ export interface IProject {
   icon: string;
   tagIds: string[];
   createdAt: string;
+  createdBy: string;
   priority: number;
   status: number;
   targetDate: Date;

--- a/frontend/plugins/operation_ui/src/modules/task/types/index.ts
+++ b/frontend/plugins/operation_ui/src/modules/task/types/index.ts
@@ -22,6 +22,7 @@ export interface ITask {
   number: string;
   tagIds: string[];
   createdAt: string;
+  createdBy: string;
   priority: number;
   status: string;
   startDate?: string;

--- a/frontend/plugins/operation_ui/src/modules/task/types/index.ts
+++ b/frontend/plugins/operation_ui/src/modules/task/types/index.ts
@@ -22,7 +22,7 @@ export interface ITask {
   number: string;
   tagIds: string[];
   createdAt: string;
-  createdBy: string;
+  createdBy?: string;
   priority: number;
   status: string;
   startDate?: string;


### PR DESCRIPTION
[Ph1. Bug] 👾 Issue 11: Task-iin anh hen uusgesen Created at, Created by log bichigdehgui bn

## Summary by Sourcery

Include creator metadata in tasks and projects by adding a createdBy field, update GraphQL schema and resolvers accordingly, and enhance the frontend activity list to display creator information using new timeline components

New Features:
- Persist and expose the creator (createdBy) field on Project and Task entities
- Display the creator and creation timestamp in the activity timeline via new CreatorInfo component

Bug Fixes:
- Add missing creation log entry for tasks and projects

Enhancements:
- Refactor activity rendering to use unified ActivityTimelineItem and ActivityItemWrapper components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity timeline shows creator (avatar or “System”) and creation time with a streamlined timeline item layout and consolidated components.
  * Added creator display component for content items.

* **API**
  * Projects and tasks include a createdBy field; new projects record creator attribution and UI queries now return creator info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 12:08:46 UTC

<h3>Summary</h3>

This PR adds creator activity tracking to Tasks and Projects by implementing a `createdBy` field across the full stack. The changes include backend schema updates, GraphQL mutations that capture the creator's user ID, and new frontend components that display creator information in activity timelines.

Key changes:
- Added `createdBy` field to Project and Task schemas and types
- Modified `createProject` mutation to set `createdBy` to the current user's ID
- Created new `CreatorInfo` component to display creator information with avatar and timestamp
- Enhanced activity timeline with unified `ActivityTimelineItem` and `ActivityItemWrapper` components
- Updated GraphQL queries to fetch creator metadata for proper display

The implementation follows existing patterns and successfully addresses the bug where creation logs were missing for tasks and projects.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor fixes needed for date formatting and import conventions
- The implementation is solid with proper backend integration and frontend display components, but has minor issues with date handling and relative imports that should be addressed
- CreatorInfo.tsx and ActivityItemWrapper.tsx need attention for date formatting and import style fixes

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| backend/plugins/operation_api/src/modules/project/graphql/resolvers/mutations/project.ts | 5/5 | Added user ID tracking to project creation - properly sets `createdBy` field |
| frontend/plugins/operation_ui/src/modules/activity/components/CreatorInfo.tsx | 3/5 | New component for displaying creator information - has relative import and date formatting issues |
| frontend/plugins/operation_ui/src/modules/activity/components/ActivityItemWrapper.tsx | 3/5 | Activity wrapper component - has relative import and date formatting issues |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant F as Frontend
    participant G as GraphQL API
    participant DB as Database
    participant AC as ActivityList

    Note over U,DB: Project/Task Creation Flow
    U->>F: Create Project/Task
    F->>G: createProject/createTask mutation
    G->>G: Extract user._id from context
    G->>DB: Save with createdBy: user._id
    DB->>G: Return created entity
    G->>F: Return project/task with createdBy

    Note over U,AC: Activity Display Flow
    U->>F: View Project/Task Details
    F->>G: getProject/getTask query
    G->>DB: Fetch with createdBy, createdAt
    DB->>G: Return project/task data
    G->>F: Return project/task with creator metadata
    
    F->>AC: ActivityList component receives contentDetail
    AC->>AC: CreatorInfo component processes createdBy
    AC->>AC: Check if createdBy exists
    
    alt Creator exists
        AC->>F: Display MembersInline with creator info
    else No creator
        AC->>F: Display "Unknown" with default avatar
    end
    
    AC->>F: Render timeline with creator info at top
```

<!-- /greptile_comment -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `createdBy` field to track and display creator information for tasks and projects across backend and frontend.
> 
>   - **Backend**:
>     - Add `createdBy` field to `IProject` in `project.ts` and `projectSchema` in `definitions/project.ts`.
>     - Update `createProject` mutation in `mutations/project.ts` to set `createdBy` to `user._id`.
>     - Modify GraphQL schema in `schema/project.ts` to include `createdBy`.
>   - **Frontend**:
>     - Add `createdBy` to `IProject` and `ITask` in `types/index.ts`.
>     - Create `CreatorInfo` component in `CreatorInfo.tsx` to display creator info.
>     - Use `ActivityItemWrapper` and `ActivityTimelineItem` in `ActivityList.tsx` for unified activity rendering.
>     - Update GraphQL queries in `getProject.tsx` and `getProjects.tsx` to fetch `createdBy`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 046ea31ef6fdf39af1c70c1d47b7329ff29db4ad. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->