### PR TITLE
Cycle member filter

### DIFF
--- a/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
+++ b/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
@@ -45,7 +45,7 @@ export const CycleProgressByMember = ({
           <HoverCard.Trigger asChild>
             <div className="flex justify-start items-center gap-2 text-sm font-normal py-1">
               <Button
-                className="p-0"
+                className="p-0 truncate max-w-[170px]"
                 variant="ghost"
                 onClick={() => {
                   setAssignee(
@@ -57,6 +57,7 @@ export const CycleProgressByMember = ({
                   memberIds={[item.assigneeId]}
                   placeholder="No Assignee"
                 />
+              </Button>
 
                 <ChartContainer config={{}} className="aspect-square size-6">
                   <RadialBarChart
@@ -92,7 +93,6 @@ export const CycleProgressByMember = ({
                 <span className="text-sm text-accent-foreground">
                   {getProgress(item)}% of {item.totalScope}
                 </span>
-              </Button>
             </div>
           </HoverCard.Trigger>
           <HoverCard.Content side="left" className="w-32 p-3">

--- a/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
+++ b/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
@@ -15,7 +15,7 @@ export const CycleProgressByMember = ({
   isCompleted: boolean;
   statistics: any;
 }) => {
-  const [assignee, setAssignee] = useQueryState<string>('assignee');
+  const [assignee, setAssignee] = useQueryState<string | null>('assignee');
 
   const { cycleProgressByMember } = useGetCycleProgressByMember({
     variables: { _id: cycleId },

--- a/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
+++ b/frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx
@@ -15,7 +15,7 @@ export const CycleProgressByMember = ({
   isCompleted: boolean;
   statistics: any;
 }) => {
-  const [assignee] = useQueryState<string>('assignee');
+  const [assignee, setAssignee] = useQueryState<string>('assignee');
 
   const { cycleProgressByMember } = useGetCycleProgressByMember({
     variables: { _id: cycleId },
@@ -43,13 +43,16 @@ export const CycleProgressByMember = ({
       {progress?.map((item) => (
         <HoverCard openDelay={150} closeDelay={150} key={item.assigneeId}>
           <HoverCard.Trigger asChild>
-            <Button
-              className="flex justify-start gap-2 items-center text-sm font-normal h-10 py-1"
-              asChild
-              variant="ghost"
-              size="lg"
-            >
-              <div>
+            <div className="flex justify-start items-center gap-2 text-sm font-normal py-1">
+              <Button
+                className="p-0"
+                variant="ghost"
+                onClick={() => {
+                  setAssignee(
+                    assignee === item.assigneeId ? null : item.assigneeId,
+                  );
+                }}
+              >
                 <MembersInline
                   memberIds={[item.assigneeId]}
                   placeholder="No Assignee"
@@ -89,8 +92,8 @@ export const CycleProgressByMember = ({
                 <span className="text-sm text-accent-foreground">
                   {getProgress(item)}% of {item.totalScope}
                 </span>
-              </div>
-            </Button>
+              </Button>
+            </div>
           </HoverCard.Trigger>
           <HoverCard.Content side="left" className="w-32 p-3">
             <div className="flex flex-col gap-1 text-muted-foreground">


### PR DESCRIPTION
[Cycle] ✅ Issue 5: gj orood neg cycl-iin Memberin ar dah Too buren haragdahgui bn
[Cycle] ✅ Issue 6: Memberin ner deer darhad filter hiih

## Summary by Sourcery

Enable interactive member filtering in the cycle progress component by integrating a query-state setter and updating the member UI to toggle the filter on click.

New Features:
- Add clickable member names that toggle the assignee filter via URL query state.

Enhancements:
- Expose the assignee setter from the useQueryState hook to control filtering.
- Refactor markup and styling to wrap only the member label in a truncated button for better layout and click behavior.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add interactive member filtering in `CycleProgressByMember.tsx` by making member names clickable to toggle the assignee filter.
> 
>   - **New Features**:
>     - Add clickable member names in `CycleProgressByMember.tsx` to toggle assignee filter using `useQueryState`.
>   - **UI/UX**:
>     - Wrap `MembersInline` in a `Button` to make member names interactive.
>     - Truncate long member names for better layout.
>   - **Logic**:
>     - Use `setAssignee` to toggle filter: set to member's ID or clear if already selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=erxes%2Ferxes-next&utm_source=github&utm_medium=referral)<sup> for 16651de681052c7b226ac5ac0323eeeee9d6570a. You can [customize](https://app.ellipsis.dev/erxes/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-02 15:15:10 UTC

<h3>Summary</h3>
This PR implements a member filter functionality for the cycle progress component in the operation UI plugin. The change enables users to click on member names to filter the cycle progress view by specific team members.

The implementation leverages an existing filtering mechanism (lines 37-39) that was already present in the code but previously had no user interface to trigger it. The developer added the `setAssignee` function to the `useQueryState` hook to enable toggling of the filter state, and restructured the UI to make member names clickable.

The change transforms the static member display into an interactive element by wrapping the `MembersInline` component in a clickable `Button`. When clicked, the button toggles the assignee filter - setting it to the member's ID if not currently selected, or clearing it (setting to null) if already selected. This creates a toggle behavior where users can switch between viewing all members' progress and focusing on a specific member's progress.

The implementation fits well within the existing codebase architecture, using the established patterns of `useQueryState` for URL state management and maintaining the existing `MembersInline` component for consistent member display across the application.

**PR Description Notes:**
- The PR description contains text in what appears to be Mongolian, making it difficult to verify the exact requirements, but the implementation appears to address member filtering functionality as indicated by "Memberin ner deer darhad filter hiih"

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| frontend/plugins/operation_ui/src/modules/cycle/components/detail/CycleProgressByMember.tsx | 4/5 | Added interactive member filtering by making member names clickable to toggle progress view filtering |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it implements a straightforward UI enhancement
- Score reflects clean implementation using existing patterns and minimal code changes to add useful functionality
- No files require special attention as the change is isolated and well-structured

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CycleProgressByMember
    participant useQueryState
    participant useGetCycleProgressByMember
    participant Button
    participant HoverCard
    
    User->>CycleProgressByMember: "View cycle progress by member"
    CycleProgressByMember->>useQueryState: "Get current assignee filter"
    useQueryState-->>CycleProgressByMember: "Return assignee state"
    
    alt Cycle not completed
        CycleProgressByMember->>useGetCycleProgressByMember: "Fetch cycle progress data"
        useGetCycleProgressByMember-->>CycleProgressByMember: "Return cycleProgressByMember"
    else Cycle completed
        CycleProgressByMember->>CycleProgressByMember: "Use statistics.progressByMember"
    end
    
    alt Cycle completed and assignee filter active
        CycleProgressByMember->>CycleProgressByMember: "Filter progress by assignee"
    end
    
    CycleProgressByMember->>CycleProgressByMember: "Render member list with progress"
    
    User->>Button: "Click member name to filter"
    Button->>useQueryState: "Toggle assignee filter"
    useQueryState-->>Button: "Update assignee state"
    Button-->>CycleProgressByMember: "Re-render with filter applied"
    
    User->>HoverCard: "Hover over member progress"
    HoverCard-->>User: "Show detailed progress breakdown"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle the assignee filter directly from the member list in Cycle Progress: click a member to filter by them; click again to clear the filter.

* **UI/UX**
  * Member entries are now accessible buttons for improved click targets and consistency.
  * Long member names are truncated to preserve layout and readability.
  * Trigger/button structure refined for more reliable interaction and visual stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->